### PR TITLE
GPU build fix + parallelism changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Submodule builds
 deps/sundials-install
-deps/gkyl-install
+deps/gkylsoft
 
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Submodule builds
 deps/sundials-install
-
 deps/gkylsoft/
 
 # Prerequisites

--- a/README.md
+++ b/README.md
@@ -126,9 +126,7 @@ mkdir deps/sundials/build
 cd deps/sundials/build
 # To install with LAPACK -- Needs to be fixed
 cmake -DCMAKE_INSTALL_PREFIX=../../sundials-install -DENABLE_MPI=ON -DSUNDIALS_INDEX_SIZE=32 -DMPI_C_COMPILER=$GKYLSOFT/openmpi/bin/mpicc -DMPI_Fortran_COMPILER=$GKYLSOFT/openmpi/bin/mpifort -DMPI_Fortran_WORKS=ON -DMPIEXEC_EXECUTABLE=$GKYLSOFT/openmpi/bin/mpiexec -DENABLE_LAPACK=ON -DLAPACK_LIBRARIES=<full-path-to-liblapacke.a> ..
-
 # To install without LAPACK -- deactivate the spack environment for possible conflicts
-
 ccmake -DCMAKE_INSTALL_PREFIX=../../sundials-install -DENABLE_MPI=ON -DSUNDIALS_INDEX_SIZE=32 -DMPI_C_COMPILER=$GKYLSOFT/openmpi-4.1.6/bin/mpicc -DMPIEXEC_EXECUTABLE=$GKYLSOFT/openmpi-4.1.6/bin/mpiexec ..
 make -j install
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We recommend that users follow the posted instructions for installing both SUNDI
 
 GkeyllZero uses a Makefile-based build system, that relies on "machine files" for configuration.  For systems where existing machine files can be used, we recommend that users follow the "Gkeyll build instructions" linked above.  We recommend that the same MPI library is used when building SUNDIALS, GkeyllZero's dependencies, GkeyllZero, and this repository, so it may be necessary to rebuild SUNDIALS above using the same MPI compiler wrappers as are used in the Gkeyll machine files.
 
-The remainder of this section assumes that GkeyllZero has not been built on this machine before, and summarize the minimal steps to install GkeyllZero and its dependencies into the `deps/gkyl-install` folder.  These closely follow the Gkeyll documentation steps for ["Installing from source manually"](https://gkeyll.readthedocs.io/en/latest/install.html#installing-from-source-manually), and so we omit explanation except where necessary.
+The remainder of this section assumes that GkeyllZero has not been built on this machine before, and summarize the minimal steps to install GkeyllZero and its dependencies into the `deps/gkylsoft` folder.  These closely follow the Gkeyll documentation steps for ["Installing from source manually"](https://gkeyll.readthedocs.io/en/latest/install.html#installing-from-source-manually), and so we omit explanation except where necessary.
 
 We assume that this repository will be built using the `gcc`, `g++` and `gfortran` compilers, and that these are already in the user's current `$PATH`.  We also assume that LAPACKE is already installed on the current system.
 
@@ -70,11 +70,11 @@ To install GkeyllZero and its dependencies (without CUDA), from the top-level fo
 
 ```bash
 cd deps
-export GKYLSOFT=$PWD/gkyl-install
+export GKYLSOFT=$PWD/gkylsoft
 cd gkylzero/install-deps
-./mkdeps.sh CC=gcc CXX=g++ FC=gfortran --prefix=$GKYLSOFT --build-superlu=yes --build-openmpi=yes
+./mkdeps.sh CC=gcc CXX=g++ FC=gfortran --prefix=$GKYLSOFT --build-superlu=yes --build-openmpi=yes --build-openblas=yes
 cd ..
-./configure CC=gcc --prefix=$GKYLSOFT --use-mpi=yes --lapack-lib=<full-path-to-liblapacke.a> --lapack-inc=<full-path-to-folder-containing-lapacke.h>
+./configure CC=gcc --prefix=$GKYLSOFT --use-mpi=yes
 make -j install
 ```
 
@@ -124,7 +124,10 @@ The following steps can be used to build SUNDIALS using a minimal configuration 
 ```bash
 mkdir deps/sundials/build
 cd deps/sundials/build
+# To install with LAPACK -- Needs to be fixed
 cmake -DCMAKE_INSTALL_PREFIX=../../sundials-install -DENABLE_MPI=ON -DSUNDIALS_INDEX_SIZE=32 -DMPI_C_COMPILER=$GKYLSOFT/openmpi/bin/mpicc -DMPI_Fortran_COMPILER=$GKYLSOFT/openmpi/bin/mpifort -DMPI_Fortran_WORKS=ON -DMPIEXEC_EXECUTABLE=$GKYLSOFT/openmpi/bin/mpiexec -DENABLE_LAPACK=ON -DLAPACK_LIBRARIES=<full-path-to-liblapacke.a> ..
+# To install without LAPACK -- deactivate the spack environment for possible conflicts
+ccmake -DCMAKE_INSTALL_PREFIX=../../sundials-install -DENABLE_MPI=ON -DSUNDIALS_INDEX_SIZE=32 -DMPI_C_COMPILER=$GKYLSOFT/openmpi-4.1.6/bin/mpicc -DMPIEXEC_EXECUTABLE=$GKYLSOFT/openmpi-4.1.6/bin/mpiexec ..
 make -j install
 ```
 

--- a/diffusion_2D/main.cpp
+++ b/diffusion_2D/main.cpp
@@ -377,8 +377,8 @@ int main(int argc, char* argv[])
       // Dominant eigenvalue estimation
       if (uopts.internaleig)
       {
-        DEE = SUNDomEigEst_Power(u, 100, 0.01, ctx);
-        if (check_flag(DEE, "SUNDomEigEst_Power", 0)) { return 1; }
+        DEE = SUNDomEigEstimator_Power(u, 100, 0.01, ctx);
+        if (check_flag(DEE, "SUNDomEigEstimator_Power", 0)) { return 1; }
 
         flag = LSRKStepSetDomEigEstimator(arkode_mem, DEE);
         if (check_flag(&flag, "LSRKStepSetDomEigEstimator", 1)) { return 1; }

--- a/gkeyll_diffusion/Makefile
+++ b/gkeyll_diffusion/Makefile
@@ -47,8 +47,8 @@ G0_LIB_DIR = ${PREFIX}/gkylzero/lib
 G0_LIB = -lgkylzero
 
 SUNDIALS_INC_DIR = ${SUN_PREFIX}/sundials-install/include
-SUNDIALS_LIB_DIR = ${SUN_PREFIX}/sundials-install/lib64
-SUNDIALS_LIB = -lsundials_arkode -lsundials_core -lsundials_sundomeigestpower -lsundials_sundomeigestarnoldi
+SUNDIALS_LIB_DIR = ${SUN_PREFIX}/sundials-install/lib
+SUNDIALS_LIB = -lsundials_arkode -lsundials_core -lsundials_sundomeigestpower # -lsundials_sundomeigestarnoldi
 SUNDIALS_RPATH = -Wl,-rpath,${SUNDIALS_LIB_DIR}
 
 USING_NVCC =

--- a/gkeyll_diffusion/Makefile
+++ b/gkeyll_diffusion/Makefile
@@ -47,7 +47,7 @@ G0_LIB_DIR = ${PREFIX}/gkylzero/lib
 G0_LIB = -lgkylzero
 
 SUNDIALS_INC_DIR = ${SUN_PREFIX}/sundials-install/include
-SUNDIALS_LIB_DIR = ${SUN_PREFIX}/sundials-install/lib
+SUNDIALS_LIB_DIR = ${SUN_PREFIX}/sundials-install/lib64
 SUNDIALS_LIB = -lsundials_arkode -lsundials_core -lsundials_sundomeigestpower -lsundials_sundomeigestarnoldi
 SUNDIALS_RPATH = -Wl,-rpath,${SUNDIALS_LIB_DIR}
 

--- a/gkeyll_diffusion/Makefile
+++ b/gkeyll_diffusion/Makefile
@@ -11,7 +11,7 @@ CUDA_ARCH ?= 70
 # Warning flags: -Wall -Wno-unused-variable -Wno-unused-function -Wno-missing-braces
 CFLAGS ?= -O3 -g -ffast-math -fPIC -MMD -MP -DGIT_COMMIT_ID=\"$(GIT_COMMIT_HASH)\"
 LDFLAGS =
-PREFIX = ${PWD}/../deps/gkyl-install
+PREFIX = ${PWD}/../deps/gkylsoft
 SUN_PREFIX = $(shell dirname ${PREFIX})
 
 # determine OS we are running on
@@ -149,25 +149,12 @@ INCLUDES = -I${G0_INC_DIR} -I${SUNDIALS_INC_DIR} -I${LAPACK_INC} -I${BLAS_INC} -
 LIB_DIRS = -L${SUNDIALS_LIB_DIR} -L${LAPACK_LIB_DIR} -L${BLAS_LIB_DIR} -L${SUPERLU_LIB_DIR} -L${MPI_LIB_DIR} -L${LUA_LIB_DIR} -L${NCCL_LIB_DIR} -L${CUDSS_LIB_DIR}
 EXT_LIBS = ${LAPACK_LIB} ${BLAS_LIB} ${SUNDIALS_LIB} ${SUNDIALS_RPATH} ${SUPERLU_LIB} ${MPI_RPATH} ${MPI_LIBS} ${LUA_RPATH} ${LUA_LIBS} ${NCCL_LIBS} ${CUDSS_RPATH} ${CUDSS_LIBS} -lm -lpthread -ldl
 
-all: gk_diffusion_1x1v_p1 test_nvector_gkylzero
+all: gk_diffusion_1x1v_p1
 
-gk_diffusion_1x1v_p1: gk_diffusion_1x1v_p1.c nvector_gkylzero.o input_handler.o
-	${CC} ${CFLAGS} ${INCLUDES} gk_diffusion_1x1v_p1.c nvector_gkylzero.o input_handler.o \
+gk_diffusion_1x1v_p1: gk_diffusion_1x1v_p1.c
+	${CC} ${CFLAGS} ${INCLUDES} src/input_handler.c src/nvector_gkylzero.c gk_diffusion_1x1v_p1.c \
 		-o gk_diffusion_1x1v_p1 \
 		-L${G0_LIB_DIR} ${G0_RPATH} ${G0_LIBS} ${LIB_DIRS} ${EXT_LIBS}
-
-test_nvector_gkylzero: test_nvector_gkylzero.c nvector_gkylzero.o
-	${CC} ${CFLAGS} ${INCLUDES} test_nvector_gkylzero.c nvector_gkylzero.o \
-		-o test_nvector_gkylzero \
-		-L${G0_LIB_DIR} ${G0_RPATH} ${G0_LIBS} ${LIB_DIRS} ${EXT_LIBS}
-
-
-
-nvector_gkylzero.o: src/nvector_gkylzero.c
-	${CC} ${CFLAGS} ${INCLUDES} -c src/nvector_gkylzero.c -o nvector_gkylzero.o
-
-input_handler.o: src/input_handler.c
-	${CC} ${CFLAGS} ${INCLUDES} -c src/input_handler.c -o input_handler.o
 
 clean:
 	rm -rf gk_diffusion_1x1v_p1 gk_diffusion_1x1v_p1.dSYM *.gkyl *.o

--- a/gkeyll_diffusion/analytic_CR_test.c
+++ b/gkeyll_diffusion/analytic_CR_test.c
@@ -26,7 +26,7 @@
 #include <arkode/arkode_lsrkstep.h> /* prototypes for LSRKStep fcts., consts */
 
 #include <sundomeigest/sundomeigest_power.h> /* access to Power Iteration module */
-#include <sundomeigest/sundomeigest_arnoldi.h> /* access to Arnoldi Iteration module */
+// #include <sundomeigest/sundomeigest_arnoldi.h> /* access to Arnoldi Iteration module */
 
 // Struct with context parameters.
 struct analytic_ctx
@@ -102,7 +102,7 @@ struct gkyl_analytic_app* gkyl_analytic_app_new(struct gkyl_analytic_app_inp* in
 
   int lower[] = {1}, upper[] = {2};
   gkyl_range_init(&app->local, 1, lower, upper);
-  printf("vol = %d\n",app->local.volume);
+  printf("vol = %ld\n",app->local.volume);
 
   app->f = mkarr(app->use_gpu, 1, app->local.volume);
 
@@ -281,8 +281,9 @@ int STS_init(struct gkyl_analytic_app* app, UserData* udata, N_Vector* y, void**
     }
     else if(udata->dee_id == 1)
     {
-      DEE = SUNDomEigEstimator_Arnoldi(ydde_init, udata->dee_krylov_dim, sunctx);
-      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi", 0)) { return 1; }
+      // DEE = SUNDomEigEstimator_Arnoldi(ydde_init, udata->dee_krylov_dim, sunctx);
+      DEE = NULL;
+      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi will be implemented in the future", 0)) { return 1; }
     }
     else
     {

--- a/gkeyll_diffusion/analytic_CR_test.c
+++ b/gkeyll_diffusion/analytic_CR_test.c
@@ -164,9 +164,6 @@ static int check_flag(void* flagvalue, const char* funcname, int opt)
    ----------------------------------------------------------------------------------
    ---------------------------------------------------------------------------------- */
 
-// Test the NVector interface
-void test_NVector(bool use_gpu);
-
 /* f routine to compute the ODE RHS function f(t,y). */
 static int f(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data)
 {

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -763,8 +763,9 @@ int efun_cell_norm(N_Vector x, N_Vector w, void* user_data)
 {
   struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* wdptr = NV_CONTENT_GKZ(w)->dataptr;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
 
-  gkyl_array_error_denom_fac(wdptr, reltol, abstol, xdptr);
+  gkyl_array_error_denom_fac_range(wdptr, reltol, abstol, xdptr, local_range);
 
   return 0;
 }

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -1202,7 +1202,7 @@ int main(int argc, char* argv[])
   if (check_flag(&flag, "LSRKStepSetSTSMethod", 1)) { return 1; }
 
   /* Specify the fixed step size for the reference STS solution */
-  flag = ARKodeSetFixedStep(arkode_mem_ref, 1.0e-5);
+  flag = ARKodeSetFixedStep(arkode_mem_ref, 5.0e-5);
   if (check_flag(&flag, "ARKodeSetFixedStep", 1)) { return 1; }
 
   if (!is_SSP)

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -37,7 +37,7 @@
 #include <arkode/arkode_lsrkstep.h> /* prototypes for LSRKStep fcts., consts */
 
 #include <sundomeigest/sundomeigest_power.h> /* access to Power Iteration module */
-#include <sundomeigest/sundomeigest_arnoldi.h> /* access to Arnoldi Iteration module */
+// #include <sundomeigest/sundomeigest_arnoldi.h> /* access to Arnoldi Iteration module */
 
 static inline void
 gkyl_diffusion_printf(struct gkyl_comm *comm, const char* format, ...)
@@ -820,8 +820,9 @@ int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
     }
     else if(udata->dee_id == 1)
     {
-      DEE = SUNDomEigEstimator_Arnoldi(*y, udata->dee_krylov_dim, sunctx);
-      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi", 0)) { return 1; }
+      // DEE = SUNDomEigEstimator_Arnoldi(*y, udata->dee_krylov_dim, sunctx);
+      DEE = NULL;
+      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi will be implemented in the future", 0)) { return 1; }
     }
     else
     {

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -693,9 +693,6 @@ static int check_flag(void* flagvalue, const char* funcname, int opt)
    ----------------------------------------------------------------------------------
    ---------------------------------------------------------------------------------- */
 
-// Test the NVector interface
-void test_NVector(bool use_gpu);
-
 sunbooleantype first_RHS_call = SUNTRUE;
 
 /* f routine to compute the ODE RHS function f(t,y). */

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -11,8 +11,8 @@
 
 #include <gkyl_null_comm.h>
 #ifdef GKYL_HAVE_MPI
-#include <mpi.h>
 #include <gkyl_mpi_comm.h>
+#include <mpi.h>
 #ifdef GKYL_HAVE_NCCL
 #include <gkyl_nccl_comm.h>
 #endif
@@ -30,22 +30,24 @@
 #include <rt_arg_parse.h>
 #include <time.h>
 
-#include "src/nvector_gkylzero.h"
 #include "src/input_handler.h"
+#include "src/nvector_gkylzero.h"
 
 #include <arkode/arkode_erkstep.h>  /* prototypes for ERKStep fcts., consts */
 #include <arkode/arkode_lsrkstep.h> /* prototypes for LSRKStep fcts., consts */
 
 #include <sundomeigest/sundomeigest_power.h> /* access to Power Iteration module */
+
 // #include <sundomeigest/sundomeigest_arnoldi.h> /* access to Arnoldi Iteration module */
 
-static inline void
-gkyl_diffusion_printf(struct gkyl_comm *comm, const char* format, ...)
+static inline void gkyl_diffusion_printf(struct gkyl_comm* comm,
+                                         const char* format, ...)
 {
   int rank;
   gkyl_comm_get_rank(comm, &rank);
 
-  if (rank == 0) {
+  if (rank == 0)
+  {
     va_list args;
     va_start(args, format);
     vprintf(format, args);
@@ -95,8 +97,8 @@ struct diffusion_ctx create_diffusion_ctx(void)
     .B0     = 1.0,  // Magnetic field.
     .diffD0 = 0.1,  // Diffusion amplitude.
 
-    .x_min      = -PI,     // Minimum x of the grid.
-    .x_max      = PI,      // Maximum x of the grid.
+    .x_min      = -PI,       // Minimum x of the grid.
+    .x_max      = PI,        // Maximum x of the grid.
     .vpar_min   = -6.0,      // Minimum vpar of the grid.
     .vpar_max   = 6.0,       // Maximum vpar of the grid.
     .poly_order = 1,         // Polynomial order of the DG basis.
@@ -121,9 +123,9 @@ struct gkyl_diffusion_app_inp
   int cells[GKYL_MAX_DIM];                         // Number of cells.
   int poly_order; // Polynomial order of the basis.
 
-  bool use_gpu;   // Whether to run on GPU.
-  int cuts[3]; // Number of subdomain in each dimension.
-  struct gkyl_comm *comm; // Communicator to use.
+  bool use_gpu;           // Whether to run on GPU.
+  int cuts[3];            // Number of subdomain in each dimension.
+  struct gkyl_comm* comm; // Communicator to use.
 
   double cfl_frac; // Factor on RHS of the CFL constraint.
 
@@ -206,7 +208,8 @@ struct gkyl_diffusion_app
 
   int cdim, vdim; // Conf- and vel-space dimensions.
 
-  struct gkyl_rect_grid grid, grid_conf, grid_vel; // Phase-, conf- and vel-space grids.
+  struct gkyl_rect_grid grid, grid_conf,
+    grid_vel; // Phase-, conf- and vel-space grids.
 
   struct gkyl_basis basis, basis_conf; // Phase- and conf-space bases.
 
@@ -217,9 +220,9 @@ struct gkyl_diffusion_app
   struct gkyl_range local_vel, local_ext_vel;   // Local vel-space ranges.
   struct gkyl_range local, local_ext;           // Local phase-space ranges.
 
-  struct gkyl_comm *comm; // Phase-space communicator.
-  struct gkyl_comm *comm_conf; // Conf-space communicator.
-  struct gkyl_rect_decomp* decomp; // Phase-space decomposition object.
+  struct gkyl_comm* comm;               // Phase-space communicator.
+  struct gkyl_comm* comm_conf;          // Conf-space communicator.
+  struct gkyl_rect_decomp* decomp;      // Phase-space decomposition object.
   struct gkyl_rect_decomp* decomp_conf; // Conf-space decomposition object.
 
   struct gk_geometry* gk_geom; // Gyrokinetic geometry.
@@ -253,7 +256,7 @@ static void apply_bc(struct gkyl_diffusion_app* app, double tcurr,
   // Apply boundary conditions.
   int num_periodic_dir = app->num_periodic_dir, cdim = app->cdim;
   gkyl_comm_array_per_sync(app->comm, &app->local, &app->local_ext,
-    num_periodic_dir, app->periodic_dirs, distf);
+                           num_periodic_dir, app->periodic_dirs, distf);
 }
 
 struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp* inp)
@@ -268,7 +271,8 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
   app->use_gpu = inp->use_gpu;
 
   app->num_periodic_dir = inp->num_periodic_dir;
-  for (int d=0; d<app->num_periodic_dir; d++) app->periodic_dirs[d] = inp->periodic_dirs[d];
+  for (int d = 0; d < app->num_periodic_dir; d++)
+    app->periodic_dirs[d] = inp->periodic_dirs[d];
 
   // Aliases for simplicity.
   int cdim = app->cdim, vdim = app->vdim;
@@ -300,34 +304,37 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
   // Global conf-space range.
   int ghost_conf[GKYL_MAX_CDIM]; // Number of ghost cells in conf-space.
   for (int d = 0; d < cdim; d++) ghost_conf[d] = 1;
-  gkyl_create_grid_ranges(&app->grid_conf, ghost_conf, &app->global_ext_conf, &app->global_conf);
+  gkyl_create_grid_ranges(&app->grid_conf, ghost_conf, &app->global_ext_conf,
+                          &app->global_conf);
 
   // Conf-space communicator object.
   int cuts_conf[GKYL_MAX_DIM];
   for (int d = 0; d < cdim; d++) cuts_conf[d] = inp->cuts[d];
-  app->decomp_conf = gkyl_rect_decomp_new_from_cuts(cdim, cuts_conf, &app->global_conf);
-  app->comm_conf = gkyl_comm_split_comm(inp->comm, 0, app->decomp_conf);
+  app->decomp_conf = gkyl_rect_decomp_new_from_cuts(cdim, cuts_conf,
+                                                    &app->global_conf);
+  app->comm_conf   = gkyl_comm_split_comm(inp->comm, 0, app->decomp_conf);
 
   // Local conf-space range.
   int rank;
   gkyl_comm_get_rank(app->comm_conf, &rank);
-  gkyl_create_ranges(&app->decomp_conf->ranges[rank], ghost_conf, &app->local_ext_conf, &app->local_conf);
+  gkyl_create_ranges(&app->decomp_conf->ranges[rank], ghost_conf,
+                     &app->local_ext_conf, &app->local_conf);
 
   // Phase-space grid.
   gkyl_rect_grid_init(&app->grid_vel, vdim, lower_vel, upper_vel, cells_vel);
-  gkyl_rect_grid_init(&app->grid, cdim+vdim, inp->lower, inp->upper, inp->cells);
+  gkyl_rect_grid_init(&app->grid, cdim + vdim, inp->lower, inp->upper,
+                      inp->cells);
 
   // Basis functions.
-  if (inp->poly_order == 1)
-    gkyl_cart_modal_gkhybrid(&app->basis, cdim, vdim);
-  else
-    gkyl_cart_modal_serendip(&app->basis, cdim + vdim, inp->poly_order);
+  if (inp->poly_order == 1) gkyl_cart_modal_gkhybrid(&app->basis, cdim, vdim);
+  else gkyl_cart_modal_serendip(&app->basis, cdim + vdim, inp->poly_order);
 
   // Global phase-space range.
   int ghost_vel[3]        = {0}; // Number of ghost cells in vel-space.
   int ghost[GKYL_MAX_DIM] = {0}; // Number of ghost cells in phase-space.
   for (int d = 0; d < cdim; d++) ghost[d] = ghost_conf[d];
-  gkyl_create_grid_ranges(&app->grid_vel, ghost_vel, &app->local_ext_vel, &app->local_vel);
+  gkyl_create_grid_ranges(&app->grid_vel, ghost_vel, &app->local_ext_vel,
+                          &app->local_vel);
   gkyl_create_grid_ranges(&app->grid, ghost, &app->global_ext, &app->global);
 
   // Phase-space communicator object.
@@ -358,28 +365,37 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
     .basis       = app->basis_conf,
     .comm        = app->comm_conf,
   };
-  geometry_inp.geo_grid = gkyl_gk_geometry_augment_grid(app->grid_conf, geometry_inp);
+  geometry_inp.geo_grid = gkyl_gk_geometry_augment_grid(app->grid_conf,
+                                                        geometry_inp);
   gkyl_cart_modal_serendip(&geometry_inp.geo_basis, 3, inp->poly_order);
   int geo_ghost[3] = {1, 1, 1};
   gkyl_create_grid_ranges(&geometry_inp.geo_grid, geo_ghost,
                           &geometry_inp.geo_global_ext, &geometry_inp.geo_global);
-  if (comm_sz > 1) {
+  if (comm_sz > 1)
+  {
     // Create local and local_ext from user-supplied local range.
-    gkyl_gk_geometry_augment_local(&app->local_conf, geo_ghost, &geometry_inp.geo_local_ext, &geometry_inp.geo_local);
+    gkyl_gk_geometry_augment_local(&app->local_conf, geo_ghost,
+                                   &geometry_inp.geo_local_ext,
+                                   &geometry_inp.geo_local);
   }
-  else {
-    memcpy(&geometry_inp.geo_local, &geometry_inp.geo_global, sizeof(struct gkyl_range));
-    memcpy(&geometry_inp.geo_local_ext, &geometry_inp.geo_global_ext, sizeof(struct gkyl_range));
+  else
+  {
+    memcpy(&geometry_inp.geo_local, &geometry_inp.geo_global,
+           sizeof(struct gkyl_range));
+    memcpy(&geometry_inp.geo_local_ext, &geometry_inp.geo_global_ext,
+           sizeof(struct gkyl_range));
   }
-  
+
   struct gk_geometry* gk_geom_3d = gkyl_gk_geometry_mapc2p_new(&geometry_inp);
 
   // Deflate geometry if necessary.
   app->gk_geom = gkyl_gk_geometry_deflate(gk_geom_3d, &geometry_inp);
   gkyl_gk_geometry_release(gk_geom_3d);
-  if (use_gpu) {
+  if (use_gpu)
+  {
     // Copy geometry from host to device.
-    struct gk_geometry* gk_geom_dev = gkyl_gk_geometry_new(app->gk_geom, &geometry_inp, use_gpu);
+    struct gk_geometry* gk_geom_dev =
+      gkyl_gk_geometry_new(app->gk_geom, &geometry_inp, use_gpu);
     gkyl_gk_geometry_release(app->gk_geom);
     app->gk_geom = gkyl_gk_geometry_acquire(gk_geom_dev);
     gkyl_gk_geometry_release(gk_geom_dev);
@@ -387,15 +403,16 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
 
   // Velocity space mapping.
   struct gkyl_mapc2p_inp c2p_in = {};
-  app->gvm = gkyl_velocity_map_new(c2p_in, app->grid, app->grid_vel,
-    app->local, app->local_ext, app->local_vel, app->local_ext_vel, use_gpu);
+  app->gvm = gkyl_velocity_map_new(c2p_in, app->grid, app->grid_vel, app->local,
+                                   app->local_ext, app->local_vel,
+                                   app->local_ext_vel, use_gpu);
 
   // Create distribution function arrays (3 for SSP-RK3).
   app->f    = mkarr(use_gpu, app->basis.num_basis, app->local_ext.volume);
   app->f1   = mkarr(use_gpu, app->basis.num_basis, app->local_ext.volume);
   app->fnew = mkarr(use_gpu, app->basis.num_basis, app->local_ext.volume);
-  app->f_ho = use_gpu? mkarr(false, app->f->ncomp, app->f->size)
-                     : gkyl_array_acquire(app->f);
+  app->f_ho = use_gpu ? mkarr(false, app->f->ncomp, app->f->size)
+                      : gkyl_array_acquire(app->f);
   gkyl_proj_on_basis* proj_distf =
     gkyl_proj_on_basis_new(&app->grid, &app->basis, inp->poly_order + 1, 1,
                            inp->initial_f_func, inp->initial_f_ctx);
@@ -408,10 +425,8 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
   // CFL frequency in phase-space.
   app->cflrate = mkarr(use_gpu, 1, app->local_ext.volume);
 
-  if (use_gpu)
-    app->omega_cfl = gkyl_cu_malloc(sizeof(double));
-  else
-    app->omega_cfl = gkyl_malloc(sizeof(double));
+  if (use_gpu) app->omega_cfl = gkyl_cu_malloc(sizeof(double));
+  else app->omega_cfl = gkyl_malloc(sizeof(double));
 
   // Create the diffusion coefficient array.
   // For now assume 2nd order diffusion in x only.
@@ -442,8 +457,11 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
                            num_periodic_dir, app->periodic_dirs, app->diffD);
 
   // Diffusion solver.
-  app->diff_slvr = gkyl_dg_updater_diffusion_gyrokinetic_new(&app->grid, &app->basis, &app->basis_conf,
-    false, diff_dir, diffusion_order, &app->local_conf, is_zero_flux, use_gpu);
+  app->diff_slvr =
+    gkyl_dg_updater_diffusion_gyrokinetic_new(&app->grid, &app->basis,
+                                              &app->basis_conf, false, diff_dir,
+                                              diffusion_order, &app->local_conf,
+                                              is_zero_flux, use_gpu);
 
   // Things needed for L2 norm diagnostic.
   app->L2_f = mkarr(use_gpu, 1, app->local_ext.volume);
@@ -458,19 +476,20 @@ struct gkyl_diffusion_app* gkyl_diffusion_app_new(struct gkyl_diffusion_app_inp*
   return app;
 }
 
-void gkyl_diffusion_app_calc_integrated_L2_f(struct gkyl_diffusion_app* app, double tm)
+void gkyl_diffusion_app_calc_integrated_L2_f(struct gkyl_diffusion_app* app,
+                                             double tm)
 {
   // Calculate the L2 norm of f.
   gkyl_dg_calc_l2_range(app->basis, 0, app->L2_f, 0, app->f, app->local);
   gkyl_array_scale_range(app->L2_f, app->grid.cellVolume, &app->local);
 
   double L2[1] = {0.0};
-  if (app->use_gpu) {
+  if (app->use_gpu)
+  {
     gkyl_array_reduce_range(app->red_L2_f, app->L2_f, GKYL_SUM, &app->local);
     gkyl_cu_memcpy(L2, app->red_L2_f, sizeof(double), GKYL_CU_MEMCPY_D2H);
   }
-  else
-    gkyl_array_reduce_range(L2, app->L2_f, GKYL_SUM, &app->local);
+  else gkyl_array_reduce_range(L2, app->L2_f, GKYL_SUM, &app->local);
 
   double L2_global[1] = {0.0};
   gkyl_comm_allreduce_host(app->comm, GKYL_DOUBLE, GKYL_SUM, 1, L2, L2_global);
@@ -491,7 +510,8 @@ void gkyl_diffusion_app_write_integrated_L2_f(struct gkyl_diffusion_app* app)
     char fileNm[sz + 1]; // ensures no buffer overflow
     snprintf(fileNm, sizeof fileNm, fmt, app->name, "L2");
 
-    if (app->is_first_integ_L2_write_call) {
+    if (app->is_first_integ_L2_write_call)
+    {
       // Write to a new file (this ensure previous output is removed).
       gkyl_dynvec_write(app->integ_L2_f, fileNm);
       app->is_first_integ_L2_write_call = false;
@@ -581,7 +601,8 @@ void gkyl_diffusion_app_write(struct gkyl_diffusion_app* app, double tm, int fra
   // copy data from device to host before writing it out
   gkyl_array_copy(app->f_ho, app->f);
 
-  gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, app->f_ho, fileNm);
+  gkyl_comm_array_write(app->comm, &app->grid, &app->local, mt, app->f_ho,
+                        fileNm);
 
   diffusion_array_meta_release(mt);
 }
@@ -591,15 +612,12 @@ void gkyl_diffusion_app_release(struct gkyl_diffusion_app* app)
   // Free memory associated with the app.
   gkyl_array_release(app->L2_f);
   gkyl_dynvec_release(app->integ_L2_f);
-  if (app->use_gpu)
-    gkyl_cu_free(app->red_L2_f);
+  if (app->use_gpu) gkyl_cu_free(app->red_L2_f);
 
   gkyl_dg_updater_diffusion_gyrokinetic_release(app->diff_slvr);
   gkyl_array_release(app->diffD);
-  if (app->use_gpu)
-    gkyl_cu_free(app->omega_cfl);
-  else
-    gkyl_free(app->omega_cfl);
+  if (app->use_gpu) gkyl_cu_free(app->omega_cfl);
+  else gkyl_free(app->omega_cfl);
 
   gkyl_array_release(app->cflrate);
   gkyl_array_release(app->f);
@@ -710,8 +728,10 @@ static int f(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data)
 
   apply_bc(app, t, fin); //apply_bc before computing the RHS
 
-  gkyl_dg_updater_diffusion_gyrokinetic_advance(app->diff_slvr, &app->local, app->diffD,
-    app->gk_geom->jacobgeo_inv, fin, app->cflrate, fout);
+  gkyl_dg_updater_diffusion_gyrokinetic_advance(app->diff_slvr, &app->local,
+                                                app->diffD,
+                                                app->gk_geom->jacobgeo_inv, fin,
+                                                app->cflrate, fout);
 
   return 0; /* return with success */
 }
@@ -731,11 +751,11 @@ static int dom_eig(sunrealtype t, N_Vector y, N_Vector fn, sunrealtype* lambdaR,
   if (app->use_gpu)
     gkyl_cu_memcpy(&omega_cfl_ho, app->omega_cfl, sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
-  else
-    omega_cfl_ho = app->omega_cfl[0];
+  else omega_cfl_ho = app->omega_cfl[0];
 
   double omega_cfl_global_ho;
-  gkyl_comm_allreduce_host(app->comm_conf, GKYL_DOUBLE, GKYL_MAX, 1, &omega_cfl_ho, &omega_cfl_global_ho);
+  gkyl_comm_allreduce_host(app->comm_conf, GKYL_DOUBLE, GKYL_MAX, 1,
+                           &omega_cfl_ho, &omega_cfl_global_ho);
 
   *lambdaR = -omega_cfl_global_ho;
   *lambdaI = SUN_RCONST(0.0);
@@ -758,8 +778,8 @@ sunrealtype abstol;
 // Error weight function for cellwise norm of y_{n-1}
 int efun_cell_norm(N_Vector x, N_Vector w, void* user_data)
 {
-  struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
-  struct gkyl_array* wdptr = NV_CONTENT_GKZ(w)->dataptr;
+  struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
+  struct gkyl_array* wdptr       = NV_CONTENT_GKZ(w)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
 
   gkyl_array_error_denom_fac_range(wdptr, reltol, abstol, xdptr, local_range);
@@ -770,7 +790,8 @@ int efun_cell_norm(N_Vector x, N_Vector w, void* user_data)
 /* general problem parameters */
 sunrealtype T0 = 0.0; /* initial time */
 
-int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void** arkode_mem)
+int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y,
+             void** arkode_mem)
 {
   /* Create the SUNDIALS context object for this simulation */
   SUNContext sunctx;
@@ -797,7 +818,7 @@ int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
   flag = ARKodeSStolerances(*arkode_mem, udata->rtol, udata->atol);
   if (check_flag(&flag, "ARKStepSStolerances", 1)) { return 1; }
 
-  SUNDomEigEstimator DEE     = NULL; /* domeig estimator object */
+  SUNDomEigEstimator DEE = NULL; /* domeig estimator object */
 
   if (udata->user_dom_eig)
   {
@@ -810,16 +831,21 @@ int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
     /* Set the initial random eigenvector for the DEE */
     //TODO: find a better way to set the initial random eigenvector
 
-    if(udata->dee_id == 0)
+    if (udata->dee_id == 0)
     {
-      DEE = SUNDomEigEstimator_Power(*y, udata->dee_max_iters, udata->dee_reltol, sunctx);
+      DEE = SUNDomEigEstimator_Power(*y, udata->dee_max_iters,
+                                     udata->dee_reltol, sunctx);
       if (check_flag(DEE, "SUNDomEigEstimator_Power", 0)) { return 1; }
     }
-    else if(udata->dee_id == 1)
+    else if (udata->dee_id == 1)
     {
       // DEE = SUNDomEigEstimator_Arnoldi(*y, udata->dee_krylov_dim, sunctx);
       DEE = NULL;
-      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi will be implemented in the future", 0)) { return 1; }
+      if (check_flag(DEE, "SUNDomEigEstimator_Arnoldi will be implemented in the future",
+                     0))
+      {
+        return 1;
+      }
     }
     else
     {
@@ -830,11 +856,19 @@ int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
     flag = LSRKStepSetDomEigEstimator(*arkode_mem, DEE);
     if (check_flag(&flag, "LSRKStepSetDomEigEstimator", 1)) { return 1; }
 
-    flag = LSRKStepSetNumDomEigEstInitPreprocessIters(*arkode_mem, udata->dee_num_init_wups);
-    if (check_flag(&flag, "LSRKStepSetNumDomEigEstInitPreprocessIters", 1)) { return 1; }
+    flag = LSRKStepSetNumDomEigEstInitPreprocessIters(*arkode_mem,
+                                                      udata->dee_num_init_wups);
+    if (check_flag(&flag, "LSRKStepSetNumDomEigEstInitPreprocessIters", 1))
+    {
+      return 1;
+    }
 
-    flag = LSRKStepSetNumDomEigEstPreprocessIters(*arkode_mem, udata->dee_num_succ_wups);
-    if (check_flag(&flag, "LSRKStepSetNumDomEigEstPreprocessIters", 1)) { return 1; }
+    flag = LSRKStepSetNumDomEigEstPreprocessIters(*arkode_mem,
+                                                  udata->dee_num_succ_wups);
+    if (check_flag(&flag, "LSRKStepSetNumDomEigEstPreprocessIters", 1))
+    {
+      return 1;
+    }
   }
 
   /* Specify after how many successful steps dom_eig is recomputed
@@ -857,7 +891,8 @@ int STS_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
   return 0;
 }
 
-int SSP_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void** arkode_mem)
+int SSP_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y,
+             void** arkode_mem)
 {
   /* Create the SUNDIALS context object for this simulation */
   SUNContext sunctx;
@@ -891,7 +926,8 @@ int SSP_init(struct gkyl_diffusion_app* app, UserData* udata, N_Vector* y, void*
   return 0;
 }
 
-int gkyl_diffusion_update(struct gkyl_diffusion_app* app, void* arkode_mem, double tout, N_Vector y, sunrealtype* tcurr)
+int gkyl_diffusion_update(struct gkyl_diffusion_app* app, void* arkode_mem,
+                          double tout, N_Vector y, sunrealtype* tcurr)
 {
   // Call integrator to evolve the solution to time tout
   int flag = ARKodeEvolve(arkode_mem, tout, y, tcurr, ARK_NORMAL);
@@ -902,7 +938,8 @@ int gkyl_diffusion_update(struct gkyl_diffusion_app* app, void* arkode_mem, doub
   return 0;
 }
 
-double compute_max_error(N_Vector u, N_Vector v, sunrealtype  t_curr, struct gkyl_diffusion_app* app)
+double compute_max_error(N_Vector u, N_Vector v, sunrealtype t_curr,
+                         struct gkyl_diffusion_app* app)
 {
   struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
   struct gkyl_array* vdptr       = NV_CONTENT_GKZ(v)->dataptr;
@@ -914,83 +951,86 @@ double compute_max_error(N_Vector u, N_Vector v, sunrealtype  t_curr, struct gky
   struct gkyl_array* wdptr; // Temporary buffer. Should change code to avoid this.
   double* red_ho = gkyl_malloc(ncomp * sizeof(double));
   double *red_local, *red_global;
-  if (app->use_gpu) {
+  if (app->use_gpu)
+  {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
-    wdptr = mkarr(true, ncomp, udptr->size);
+    wdptr      = mkarr(true, ncomp, udptr->size);
   }
-  else {
+  else
+  {
     red_local  = gkyl_malloc(ncomp * sizeof(double));
     red_global = gkyl_malloc(ncomp * sizeof(double));
-    wdptr = mkarr(false, ncomp, udptr->size);
+    wdptr      = mkarr(false, ncomp, udptr->size);
   }
 
   gkyl_array_set_range(wdptr, 1.0, udptr, local_range);
   gkyl_array_accumulate_range(wdptr, -1.0, vdptr, local_range);
 
   gkyl_array_reduce_range(red_local, wdptr, GKYL_ABS_MAX, local_range);
-  gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_MAX, ncomp, red_local, red_global);
+  gkyl_comm_allreduce(app->comm, GKYL_DOUBLE, GKYL_MAX, ncomp, red_local,
+                      red_global);
 
   if (app->use_gpu)
-    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else
-    memcpy(red_ho, red_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
+                   GKYL_CU_MEMCPY_D2H);
+  else memcpy(red_ho, red_global, ncomp * sizeof(double));
 
   // Reduce over components.
-  for (int i = 0; i < ncomp; i++)
-    error = fmax(error, fabs(red_ho[i]));
+  for (int i = 0; i < ncomp; i++) error = fmax(error, fabs(red_ho[i]));
 
   gkyl_free(red_ho);
-  if (app->use_gpu) {
-    gkyl_cu_free(red_local );
+  if (app->use_gpu)
+  {
+    gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);
   }
-  else {
-    gkyl_free(red_local );
+  else
+  {
+    gkyl_free(red_local);
     gkyl_free(red_global);
   }
 
   gkyl_array_release(wdptr);
 
-  gkyl_diffusion_printf(app->comm, "\nmax error is %e at t = %g over the whole domain\n", error, t_curr);
+  gkyl_diffusion_printf(app->comm,
+                        "\nmax error is %e at t = %g over the whole domain\n",
+                        error, t_curr);
 
   return error;
 }
 
-static inline struct gkyl_comm*
-gkyl_diffusion_create_comm(struct gkyl_app_args app_args)
+static inline struct gkyl_comm* gkyl_diffusion_create_comm(
+  struct gkyl_app_args app_args)
 {
   // Construct communicator for use in app.
-  struct gkyl_comm *comm;
+  struct gkyl_comm* comm;
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_gpu && app_args.use_mpi) {
+  if (app_args.use_gpu && app_args.use_mpi)
+  {
 #ifdef GKYL_HAVE_NCCL
-    comm = gkyl_nccl_comm_new( &(struct gkyl_nccl_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-      }
-    );
+    comm = gkyl_nccl_comm_new(&(struct gkyl_nccl_comm_inp){
+      .mpi_comm = MPI_COMM_WORLD,
+    });
 #else
     fprintf(stderr, "\nERROR: Using -g and -M together requires NCCL.\n");
     assert(0 == 1);
 #endif
   }
-  else if (app_args.use_mpi) {
-    comm = gkyl_mpi_comm_new( &(struct gkyl_mpi_comm_inp) {
-        .mpi_comm = MPI_COMM_WORLD,
-      }
-    );
+  else if (app_args.use_mpi)
+  {
+    comm = gkyl_mpi_comm_new(&(struct gkyl_mpi_comm_inp){
+      .mpi_comm = MPI_COMM_WORLD,
+    });
   }
-  else {
-    comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-        .use_gpu = app_args.use_gpu
-      }
-    );
+  else
+  {
+    comm = gkyl_null_comm_inew(
+      &(struct gkyl_null_comm_inp){.use_gpu = app_args.use_gpu});
   }
 #else
-  comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .use_gpu = app_args.use_gpu
-    }
-  );
+  comm = gkyl_null_comm_inew(
+    &(struct gkyl_null_comm_inp){.use_gpu = app_args.use_gpu});
 #endif
   return comm;
 }
@@ -1003,18 +1043,20 @@ double sol_time = 0.0;
 
 int main(int argc, char* argv[])
 {
-  UserData* udata  = NULL; // user data structure
+  UserData* udata = NULL; // user data structure
 
   // Allocate and initialize user data structure with default values. The
   // defaults may be overwritten by command line inputs in ReadInputs below.
-  udata = (UserData*) malloc(sizeof(UserData));
-  if (udata == NULL) {
+  udata = (UserData*)malloc(sizeof(UserData));
+  if (udata == NULL)
+  {
     fprintf(stderr, "\nERROR: failed to allocate memory for UserData\n");
     return 1;
   }
 
   flag = InitUserData(udata);
-  if (check_flag(&flag, "InitUserData", 1)) { 
+  if (check_flag(&flag, "InitUserData", 1))
+  {
     free(udata);
     return 1;
   }
@@ -1026,38 +1068,37 @@ int main(int argc, char* argv[])
   struct gkyl_app_args app_args = parse_app_args(argc, argv);
 
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_mpi) {
-    MPI_Init(&argc, &argv);
-  }
+  if (app_args.use_mpi) { MPI_Init(&argc, &argv); }
 #endif
 
   // Create the context struct.
   struct diffusion_ctx ctx = create_diffusion_ctx();
 
   // Construct communicator for use in app.
-  struct gkyl_comm *comm = gkyl_diffusion_create_comm(app_args);
+  struct gkyl_comm* comm = gkyl_diffusion_create_comm(app_args);
   int my_rank;
   gkyl_comm_get_rank(comm, &my_rank);
 
   // Update the context with user inputs.
   ctx.diffD0 = udata->k;
-  ctx.t_end = udata->tf;
-  reltol = udata->rtol;
-  abstol = udata->atol;
+  ctx.t_end  = udata->tf;
+  reltol     = udata->rtol;
+  abstol     = udata->atol;
 
-  if(udata->method == ARKODE_LSRK_RKC_2 || udata->method == ARKODE_LSRK_RKL_2)
+  if (udata->method == ARKODE_LSRK_RKC_2 || udata->method == ARKODE_LSRK_RKL_2)
   {
     is_SSP = SUNFALSE;
   }
-  else if(udata->method == ARKODE_LSRK_SSP_S_2 ||
-          udata->method == ARKODE_LSRK_SSP_S_3 ||
-          udata->method == ARKODE_LSRK_SSP_10_4)
+  else if (udata->method == ARKODE_LSRK_SSP_S_2 ||
+           udata->method == ARKODE_LSRK_SSP_S_3 ||
+           udata->method == ARKODE_LSRK_SSP_10_4)
   {
     is_SSP = SUNTRUE;
-    if(udata->method == ARKODE_LSRK_SSP_10_4 && udata->num_SSP_stages != 10)
+    if (udata->method == ARKODE_LSRK_SSP_10_4 && udata->num_SSP_stages != 10)
     {
       udata->num_SSP_stages = 10; // Set to 10 for ARKODE_LSRK_SSP_10_
-      fprintf(stderr, "\nWARNING: num_SSP_stages reset to default 10 for ARKODE_LSRK_SSP_10_4\n");
+      fprintf(stderr, "\nWARNING: num_SSP_stages reset to default 10 for "
+                      "ARKODE_LSRK_SSP_10_4\n");
     }
   }
   else
@@ -1082,7 +1123,7 @@ int main(int argc, char* argv[])
     .cfl_frac = 0.5, // CFL factor.
 
     .num_periodic_dir = 1, // Periodic along x.
-    .periodic_dirs = { 0 },
+    .periodic_dirs    = {0},
 
     // Mapping from computational to physical space.
     .mapc2p_func = mapc2p,
@@ -1101,8 +1142,8 @@ int main(int argc, char* argv[])
     .initial_f_ctx  = &ctx,
 
     .use_gpu = app_args.use_gpu, // Whether to run on GPU.
-    .cuts = { app_args.cuts[0] },
-    .comm = comm,
+    .cuts    = {app_args.cuts[0]},
+    .comm    = comm,
   };
   strcpy(app_inp.name, ctx.name);
 
@@ -1199,7 +1240,8 @@ int main(int argc, char* argv[])
   {
   case 1:
     y->ops->nvwrmsnorm = N_VWrmsNorm_abs_comp_Gkylzero;
-    gkyl_diffusion_printf(comm, "\nUsing WRMSNorm with componentwise absolute values\n");
+    gkyl_diffusion_printf(comm, "\nUsing WRMSNorm with componentwise absolute "
+                                "values\n");
     break;
 
   case 2:
@@ -1210,9 +1252,12 @@ int main(int argc, char* argv[])
     break;
   }
 
-  gkyl_diffusion_printf(comm, "\nNumber of cells             = %ld", app->global.volume);
-  gkyl_diffusion_printf(comm, "\nNumber of DoFs in each cell = %ld", app->f->ncomp);
-  gkyl_diffusion_printf(comm, "\nNumber of DoFs              = %ld\n", app->global.volume * app->f->ncomp);
+  gkyl_diffusion_printf(comm, "\nNumber of cells             = %ld",
+                        app->global.volume);
+  gkyl_diffusion_printf(comm, "\nNumber of DoFs in each cell = %ld",
+                        app->f->ncomp);
+  gkyl_diffusion_printf(comm, "\nNumber of DoFs              = %ld\n",
+                        app->global.volume * app->f->ncomp);
 
   double tout      = 0;
   double max_error = 0.0;
@@ -1228,25 +1273,28 @@ int main(int argc, char* argv[])
     }
     tout += dt;
 
-    gkyl_diffusion_printf(comm, "\nTaking time-step %ld at t = %g ...", step, t_curr);
+    gkyl_diffusion_printf(comm, "\nTaking time-step %ld at t = %g ...", step,
+                          t_curr);
 
     // Update the reference solution
     ref_start = clock();
     flag      = gkyl_diffusion_update(app, arkode_mem_ref, tout, yref, &t_curr);
-    if (check_flag(&flag, "gkyl_diffusion_update", 1)) 
+    if (check_flag(&flag, "gkyl_diffusion_update", 1))
     {
-      gkyl_diffusion_printf(comm, "** Update method failed! Aborting reference simulation ....\n");
+      gkyl_diffusion_printf(comm, "** Update method failed! Aborting reference "
+                                  "simulation ....\n");
       break;
     }
-    ref_end   = clock();
+    ref_end = clock();
     ref_time += ((double)(ref_end - ref_start)) / CLOCKS_PER_SEC;
 
     // Update the computed solution
     start = clock();
     flag  = gkyl_diffusion_update(app, arkode_mem, tout, y, &t_curr);
-    if (check_flag(&flag, "gkyl_diffusion_update", 1)) 
+    if (check_flag(&flag, "gkyl_diffusion_update", 1))
     {
-      gkyl_diffusion_printf(comm, "** Update method failed! Aborting simulation ....\n");
+      gkyl_diffusion_printf(comm, "** Update method failed! Aborting "
+                                  "simulation ....\n");
       break;
     }
     end = clock();
@@ -1267,19 +1315,20 @@ int main(int argc, char* argv[])
   if (my_rank == 0)
     ARKodePrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
 
-  gkyl_diffusion_printf(comm, "\nmax-in-space and max-in-time error is %e over D x [%g, %g]\n\n", max_error, T0, t_curr);
+  gkyl_diffusion_printf(comm, "\nmax-in-space and max-in-time error is %e over D x [%g, %g]\n\n",
+                        max_error, T0, t_curr);
 
-  gkyl_diffusion_printf(comm, "Reference solution CPU time: %f seconds\n", ref_time);
-  gkyl_diffusion_printf(comm, " Computed solution CPU time: %f seconds\n", sol_time);
+  gkyl_diffusion_printf(comm, "Reference solution CPU time: %f seconds\n",
+                        ref_time);
+  gkyl_diffusion_printf(comm, " Computed solution CPU time: %f seconds\n",
+                        sol_time);
 
   // Free the app.
   gkyl_array_release(fref);
   gkyl_diffusion_app_release(app);
 
 #ifdef GKYL_HAVE_MPI
-  if (app_args.use_mpi) {
-    MPI_Finalize();
-  }
+  if (app_args.use_mpi) { MPI_Finalize(); }
 #endif
 
   return 0;

--- a/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
+++ b/gkeyll_diffusion/gk_diffusion_1x1v_p1.c
@@ -951,21 +951,19 @@ double compute_max_error(N_Vector u, N_Vector v, sunrealtype t_curr,
 
   // TODO: change code so these allocations only happen once.
   int ncomp = udptr->ncomp;
-  struct gkyl_array* wdptr; // Temporary buffer. Should change code to avoid this.
   double* red_ho = gkyl_malloc(ncomp * sizeof(double));
   double *red_local, *red_global;
   if (app->use_gpu)
   {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
-    wdptr      = mkarr(true, ncomp, udptr->size);
   }
   else
   {
     red_local  = gkyl_malloc(ncomp * sizeof(double));
     red_global = gkyl_malloc(ncomp * sizeof(double));
-    wdptr      = mkarr(false, ncomp, udptr->size);
   }
+  struct gkyl_array* wdptr = mkarr(app->use_gpu, ncomp, udptr->size); // Temporary buffer. Should change code to avoid this.
 
   gkyl_array_set_range(wdptr, 1.0, udptr, local_range);
   gkyl_array_accumulate_range(wdptr, -1.0, vdptr, local_range);
@@ -993,7 +991,6 @@ double compute_max_error(N_Vector u, N_Vector v, sunrealtype t_curr,
     gkyl_free(red_local);
     gkyl_free(red_global);
   }
-
   gkyl_array_release(wdptr);
 
   gkyl_diffusion_printf(app->comm,

--- a/gkeyll_diffusion/runtests-gk_diffusion_1x1v_p1.py
+++ b/gkeyll_diffusion/runtests-gk_diffusion_1x1v_p1.py
@@ -102,7 +102,7 @@ user_dom_eig = [False, True]
 dee_id = 0
 dee_init_wups = 0
 dee_succ_wups = 0
-dee_maxiters_val = [100]
+dee_maxiters_val = [100, 1000]
 dee_reltol = 1e-1
 
 # flags to enable/disable classes of tests

--- a/gkeyll_diffusion/scripts/ATR_DEE_comparison_rtol_error.py
+++ b/gkeyll_diffusion/scripts/ATR_DEE_comparison_rtol_error.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+#df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+#df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+normtype_opts = df["normtype"].unique()
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for normtype in normtype_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["normtype"] == normtype)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (user_dom_eig, group) in enumerate(df_method.groupby("user_dom_eig")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["rtol"],
+                    group[error_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, user_dom_eig={user_dom_eig}"
+                )
+
+        plt.xlabel("rtol")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs rtol (k={k_val}, normtype={normtype})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and normtype
+        filename = f"error_vs_rtol_k_{k_val}_normtype_{normtype}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_DEE_comparison_runtime_error.py
+++ b/gkeyll_diffusion/scripts/ATR_DEE_comparison_runtime_error.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+#df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+#df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+normtype_opts = df["normtype"].unique()
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for normtype in normtype_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["normtype"] == normtype)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (user_dom_eig, group) in enumerate(df_method.groupby("user_dom_eig")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["Runtime"],
+                    group[error_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, user_dom_eig={user_dom_eig}"
+                )
+
+        plt.xlabel("Runtime")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs Runtime (k={k_val}, normtype={normtype})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and normtype
+        filename = f"error_vs_Runtime_k_{k_val}_normtype_{normtype}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_dee_maxiters_comparison.py
+++ b/gkeyll_diffusion/scripts/ATR_dee_maxiters_comparison.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+domeig_col = "MaxSpectralRadius"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[domeig_col], errors='coerce').notnull()]
+df = df[df[domeig_col] < 1e20]  # remove blow-ups
+
+# Remove SSP/RKC and 
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+df = df[df["normtype"] != 2]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+normtype_opts = df["normtype"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for normtype in normtype_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["normtype"] == normtype)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (user_dom_eig, group) in enumerate(df_method.groupby("user_dom_eig")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["dee_maxiters"],
+                    group[domeig_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, user_dom_eig={user_dom_eig}"
+                )
+
+        plt.xlabel("dee_maxiters")
+        plt.ylabel("MaxSpectralRadius")
+        plt.title(f"MaxSpectralRadius vs dee_maxiters (k={k_val})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and normtype
+        filename = f"MaxSpectralRadius_vs_dee_maxiters_k_{k_val}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_eigensafety_plots.py
+++ b/gkeyll_diffusion/scripts/ATR_eigensafety_plots.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+# df = df[~df["method"].str.contains("RKL", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+norm_types = df["normtype"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for norm_type in sorted(norm_types):
+    for k_val in sorted(k_values):
+        for user_dom in user_dom_opts:
+            plt.figure(figsize=(10,6))
+            df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom) & (df["normtype"] == norm_type)]
+
+            for i, method in enumerate(methods):
+                df_method = df_subset[df_subset["method"] == method]
+                for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                    marker = markers[(i * 5 + j) % len(markers)]
+                    linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                    plt.loglog(
+                        group["rtol"],
+                        group[error_col],
+                        marker=marker,
+                        linestyle=linestyle,
+                        linewidth=1.5,
+                        markersize=6,
+                        label=f"{method}, eigsafety={eigsafety}"
+                    )
+
+        plt.xlabel("rtol")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs Relative Tolerance (k={k_val}, user_dom_eig={user_dom}), normtype={norm_type})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and user_dom_eig
+        filename = f"error_vs_rtol_k_{k_val}_userdom_{user_dom}_normtype_{norm_type}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_error_vs_rtol.py
+++ b/gkeyll_diffusion/scripts/ATR_error_vs_rtol.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+#df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+#df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for user_dom in user_dom_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (normtype, group) in enumerate(df_method.groupby("normtype")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["rtol"],
+                    group[error_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, normtype={normtype}"
+                )
+
+        plt.xlabel("rtol")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs Rel Tol (k={k_val}, user_dom_eig={user_dom})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and user_dom_eig
+        filename = f"error_vs_rtol_k_{k_val}_userdom_{user_dom}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_rtol_fail_rate.py
+++ b/gkeyll_diffusion/scripts/ATR_rtol_fail_rate.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "rtol"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+#df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+#df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+normtype_opts = df["normtype"].unique()
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for normtype in normtype_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["normtype"] == normtype)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (user_dom_eig, group) in enumerate(df_method.groupby("user_dom_eig")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                failure_rate = group["Fails"] / group["Steps"];
+                plt.semilogx(
+                    group[error_col],
+                    failure_rate,
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, user_dom_eig={user_dom_eig}"
+                )
+                # Force y-axis ticks to be integers
+                ax = plt.gca()
+                ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+        plt.ylabel("failure rate")
+        plt.xlabel("rtol")
+        plt.title(f"rtol vs failure rate (k={k_val}, normtype={normtype})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and normtype
+        filename = f"rtol_vs_FR_k_{k_val}_normtype_{normtype}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_rtol_fails.py
+++ b/gkeyll_diffusion/scripts/ATR_rtol_fails.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "rtol"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+#df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+#df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+normtype_opts = df["normtype"].unique()
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for normtype in normtype_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["normtype"] == normtype)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (user_dom_eig, group) in enumerate(df_method.groupby("user_dom_eig")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.semilogx(
+                    group[error_col],
+                    group["Fails"],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, user_dom_eig={user_dom_eig}"
+                )
+                # Force y-axis ticks to be integers
+                ax = plt.gca()
+                ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+        plt.ylabel("Fails")
+        plt.xlabel("rtol")
+        plt.title(f"rtol vs Fails (k={k_val}, normtype={normtype})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and normtype
+        filename = f"rtol_vs_Fails_k_{k_val}_normtype_{normtype}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/ATR_rtol_vs_fails_for_each_eigsafety.py
+++ b/gkeyll_diffusion/scripts/ATR_rtol_vs_fails_for_each_eigsafety.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_adaptive.xlsx", sheet_name="Sheet1")
+
+# Use Fails column as fail metric
+fail_col = "Fails"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[fail_col], errors='coerce').notnull()]
+df = df[df[fail_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+# df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+norm_types = df["normtype"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for norm_type in sorted(norm_types):
+    for k_val in sorted(k_values):
+        for user_dom in user_dom_opts:
+            plt.figure(figsize=(10,6))
+            df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom) & (df["normtype"] == norm_type)]
+
+            for i, method in enumerate(methods):
+                df_method = df_subset[df_subset["method"] == method]
+                for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                    marker = markers[(i * 5 + j) % len(markers)]
+                    linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                    plt.semilogx(
+                        group["rtol"],
+                        group[fail_col],
+                        marker=marker,
+                        linestyle=linestyle,
+                        linewidth=1.5,
+                        markersize=6,
+                        label=f"{method}, eigsafety={eigsafety}"
+                    )
+
+        plt.xlabel("rtol")
+        plt.ylabel("Fails")
+        plt.title(f"Fails vs Tolerance (k={k_val}, user_dom_eig={user_dom}), normtype={norm_type})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and user_dom_eig
+        filename = f"fails_vs_rtol_k_{k_val}_userdom_{user_dom}_normtype_{norm_type}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/FTR_SSP_blowups.py
+++ b/gkeyll_diffusion/scripts/FTR_SSP_blowups.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_fixed.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+# df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+# df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+norm_types = df["normtype"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for norm_type in sorted(norm_types):
+    for k_val in sorted(k_values):
+        for user_dom in user_dom_opts:
+            plt.figure(figsize=(10,6))
+            df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom)]
+
+            for i, method in enumerate(methods):
+                df_method = df_subset[df_subset["method"] == method]
+                for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                    marker = markers[(i * 5 + j) % len(markers)]
+                    linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                    plt.loglog(
+                        group["h"],
+                        group[error_col],
+                        marker=marker,
+                        linestyle=linestyle,
+                        linewidth=1.5,
+                        markersize=6,
+                        label=f"{method}"
+                    )
+
+            plt.xlabel("h")
+            plt.ylabel("Error (Accuracy)")
+            plt.title(f"Error vs Step Size (k={k_val}, user_dom_eig={user_dom})")
+            plt.legend()
+            plt.grid(True, which="both", ls="--", alpha=0.5)
+            plt.tight_layout()
+
+            # Save separate plot for each combination of k and user_dom_eig
+            filename = f"error_vs_h_k_{k_val}_userdom_{user_dom}.png"
+            plt.savefig(filename, dpi=300)
+            print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/FTR_computational_efficiency.py
+++ b/gkeyll_diffusion/scripts/FTR_computational_efficiency.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_fixed.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+# df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+# df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+norm_types = df["normtype"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for norm_type in sorted(norm_types):
+    for k_val in sorted(k_values):
+        for user_dom in user_dom_opts:
+            plt.figure(figsize=(10,6))
+            df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom)]
+
+            for i, method in enumerate(methods):
+                df_method = df_subset[df_subset["method"] == method]
+                for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                    marker = markers[(i * 5 + j) % len(markers)]
+                    linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                    plt.loglog(
+                        group["Runtime"],
+                        group[error_col],
+                        marker=marker,
+                        linestyle=linestyle,
+                        linewidth=1.5,
+                        markersize=6,
+                        label=f"{method}"
+                    )
+
+            plt.xlabel("Runtime")
+            plt.ylabel("Error (Accuracy)")
+            plt.title(f"Error vs Run Time (k={k_val}, user_dom_eig={user_dom})")
+            plt.legend()
+            plt.grid(True, which="both", ls="--", alpha=0.5)
+            plt.tight_layout()
+
+            # Save separate plot for each combination of k and user_dom_eig
+            filename = f"error_vs_h_k_{k_val}_userdom_{user_dom}.png"
+            plt.savefig(filename, dpi=300)
+            print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/FTR_eigensafety_plots_RKC.py
+++ b/gkeyll_diffusion/scripts/FTR_eigensafety_plots_RKC.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_fixed.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+df = df[~df["method"].str.contains("RKL", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for user_dom in user_dom_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["h"],
+                    group[error_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, eigsafety={eigsafety}"
+                )
+
+        plt.xlabel("h (step size)")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs Step Size (k={k_val}, user_dom_eig={user_dom})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and user_dom_eig
+        filename = f"error_vs_h_k_{k_val}_userdom_{user_dom}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/FTR_eigensafety_plots_RKL.py
+++ b/gkeyll_diffusion/scripts/FTR_eigensafety_plots_RKL.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend
+import matplotlib.pyplot as plt
+
+# Load data
+df = pd.read_excel("results_gk_diffusion_1x1v_p1_fixed.xlsx", sheet_name="Sheet1")
+
+# Use Accuracy column as error metric
+error_col = "Accuracy"
+
+# Filter only valid (finite) errors
+df = df[pd.to_numeric(df[error_col], errors='coerce').notnull()]
+df = df[df[error_col] < 1e20]  # remove blow-ups
+
+# Remove SSP results if present
+df = df[~df["method"].str.contains("SSP", case=False, na=False)]
+df = df[~df["method"].str.contains("RKC", case=False, na=False)]
+
+# Unique methods
+methods = df["method"].unique()
+k_values = df["k"].unique()
+user_dom_opts = df["user_dom_eig"].unique()
+
+# Define a set of markers and line styles to avoid overlap confusion
+markers = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "X"]
+linestyles = ["-", "--", "-.", ":"]
+
+for k_val in sorted(k_values):
+    for user_dom in user_dom_opts:
+        plt.figure(figsize=(10,6))
+        df_subset = df[(df["k"] == k_val) & (df["user_dom_eig"] == user_dom)]
+
+        for i, method in enumerate(methods):
+            df_method = df_subset[df_subset["method"] == method]
+            for j, (eigsafety, group) in enumerate(df_method.groupby("eigsafety")):
+                marker = markers[(i * 5 + j) % len(markers)]
+                linestyle = linestyles[(i * 3 + j) % len(linestyles)]
+                plt.loglog(
+                    group["h"],
+                    group[error_col],
+                    marker=marker,
+                    linestyle=linestyle,
+                    linewidth=1.5,
+                    markersize=6,
+                    label=f"{method}, eigsafety={eigsafety}"
+                )
+
+        plt.xlabel("h (step size)")
+        plt.ylabel("Error (Accuracy)")
+        plt.title(f"Error vs Step Size (k={k_val}, user_dom_eig={user_dom})")
+        plt.legend()
+        plt.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        # Save separate plot for each combination of k and user_dom_eig
+        filename = f"error_vs_h_k_{k_val}_userdom_{user_dom}.png"
+        plt.savefig(filename, dpi=300)
+        print(f"Plot saved as {filename}")

--- a/gkeyll_diffusion/scripts/filter_dee_maxiters.py
+++ b/gkeyll_diffusion/scripts/filter_dee_maxiters.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+filename = "results_gk_diffusion_1x1v_p1_adaptive.xlsx"
+
+df_a = pd.read_excel(filename, engine='openpyxl')
+
+df_filtered_a = df_a[(df_a['dee_maxiters'] == 100) | (df_a["method"].str.contains("SSP", case=False, na=False))]
+
+df_filtered_a.to_excel(filename, index=False)
+
+filename = "results_gk_diffusion_1x1v_p1_fixed.xlsx"
+
+df_f = pd.read_excel(filename, engine='openpyxl')
+
+df_filtered_f = df_f[(df_f['dee_maxiters'] == 100) | (df_f["method"].str.contains("SSP", case=False, na=False))]
+
+df_filtered_f.to_excel(filename, index=False)

--- a/gkeyll_diffusion/scripts/filter_eigsafety.py
+++ b/gkeyll_diffusion/scripts/filter_eigsafety.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+filename = "results_gk_diffusion_1x1v_p1_adaptive.xlsx"
+
+df_a = pd.read_excel(filename, engine='openpyxl')
+
+df_filtered_a = df_a[(df_a['eigsafety'] == 1.1) | (df_a["method"].str.contains("SSP", case=False, na=False))]
+
+df_filtered_a.to_excel(filename, index=False)
+
+filename = "results_gk_diffusion_1x1v_p1_fixed.xlsx"
+
+df_f = pd.read_excel(filename, engine='openpyxl')
+
+df_filtered_f = df_f[(df_f['eigsafety'] == 1.1) | (df_f["method"].str.contains("SSP", case=False, na=False))]
+
+df_filtered_f.to_excel(filename, index=False)

--- a/gkeyll_diffusion/src/input_handler.c
+++ b/gkeyll_diffusion/src/input_handler.c
@@ -34,11 +34,11 @@ int InitUserData(UserData* udata)
   udata->tf = ONE;
 
   // Integrator settings
-  udata->rtol        = SUN_RCONST(1.e-5);  // relative tolerance
-  udata->atol        = SUN_RCONST(1.e-12); // absolute tolerance
-  udata->hfixed      = ZERO;               // using adaptive step sizes
-  udata->maxsteps    = 100000;             // max steps between outputs
-  udata->wrms_norm_type = 2;               // cellwise wrms norm
+  udata->rtol           = SUN_RCONST(1.e-5);  // relative tolerance
+  udata->atol           = SUN_RCONST(1.e-12); // absolute tolerance
+  udata->hfixed         = ZERO;               // using adaptive step sizes
+  udata->maxsteps       = 100000;             // max steps between outputs
+  udata->wrms_norm_type = 2;                  // cellwise wrms norm
 
   // LSRKStep options
   udata->method          = ARKODE_LSRK_RKL_2; // RKL
@@ -48,11 +48,11 @@ int InitUserData(UserData* udata)
   udata->eigsafety       = SUN_RCONST(1.01); // 1% safety factor
 
   // Output variables
-  udata->nout   = 10; // Number of output times
+  udata->nout = 10; // Number of output times
 
   // DEE options
-  udata->user_dom_eig      = SUNFALSE; // No user-provided dominant eigenvalue function
-  udata->dee_id            = 0; // DEE ID (0 for PI and 1 for Arnoldi)
+  udata->user_dom_eig = SUNFALSE; // No user-provided dominant eigenvalue function
+  udata->dee_id            = 0;   // DEE ID (0 for PI and 1 for Arnoldi)
   udata->dee_num_init_wups = 100;
   udata->dee_num_succ_wups = 0;
   udata->dee_max_iters     = 1000;
@@ -64,29 +64,32 @@ int InitUserData(UserData* udata)
 }
 
 // Function to check if a string is a valid integer
-sunbooleantype isInteger(const char *str) {
-    if (str == NULL || *str == '\0') { // Handle empty or NULL strings
-        return SUNFALSE;
-    }
+sunbooleantype isInteger(const char* str)
+{
+  if (str == NULL || *str == '\0')
+  { // Handle empty or NULL strings
+    return SUNFALSE;
+  }
 
-    // Handle optional leading sign
-    int i = 0;
-    if (str[0] == '-' || str[0] == '+') {
-        i = 1;
-    }
+  // Handle optional leading sign
+  int i = 0;
+  if (str[0] == '-' || str[0] == '+') { i = 1; }
 
-    // Check if there are any digits after the sign (if present)
-    if (str[i] == '\0') {
-        return SUNFALSE; // Only a sign, no digits
-    }
+  // Check if there are any digits after the sign (if present)
+  if (str[i] == '\0')
+  {
+    return SUNFALSE; // Only a sign, no digits
+  }
 
-    // Iterate through the rest of the string
-    for (; str[i] != '\0'; i++) {
-        if (!isdigit(str[i])) {
-            return SUNFALSE; // Found a non-digit character
-        }
+  // Iterate through the rest of the string
+  for (; str[i] != '\0'; i++)
+  {
+    if (!isdigit(str[i]))
+    {
+      return SUNFALSE; // Found a non-digit character
     }
-    return SUNTRUE; // All characters are digits (or a valid sign followed by digits)
+  }
+  return SUNTRUE; // All characters are digits (or a valid sign followed by digits)
 }
 
 // Read command line inputs
@@ -100,20 +103,29 @@ int ReadInputs(int argc, char** argv, UserData* udata)
     char* arg = argv[arg_idx++];
 
     // Gkeyll runtime arguments.
-    if (strcmp(arg, "-g") == 0) { }
-    else if (strcmp(arg, "-M") == 0) { }
-    else if (strcmp(arg, "-s") == 0) { }
-    else if (strcmp(arg, "-r") == 0) { }
-    else if (strcmp(arg, "-o") == 0) { }
-    else if (strcmp(arg, "-c") == 0) { }
+    if (strcmp(arg, "-g") == 0) {}
+    else if (strcmp(arg, "-M") == 0) {}
+    else if (strcmp(arg, "-s") == 0) {}
+    else if (strcmp(arg, "-r") == 0) {}
+    else if (strcmp(arg, "-o") == 0) {}
+    else if (strcmp(arg, "-c") == 0) {}
     // Diffusion parameters
     else if (strcmp(arg, "--k") == 0) { udata->k = atof(argv[arg_idx++]); }
     // Temporal domain settings
     else if (strcmp(arg, "--tf") == 0) { udata->tf = atof(argv[arg_idx++]); }
     // Integrator settings
-    else if (strcmp(arg, "--rtol") == 0) { udata->rtol = atof(argv[arg_idx++]); }
-    else if (strcmp(arg, "--atol") == 0) { udata->atol = atof(argv[arg_idx++]); }
-    else if (strcmp(arg, "--fixedstep") == 0) { udata->hfixed = atof(argv[arg_idx++]); }
+    else if (strcmp(arg, "--rtol") == 0)
+    {
+      udata->rtol = atof(argv[arg_idx++]);
+    }
+    else if (strcmp(arg, "--atol") == 0)
+    {
+      udata->atol = atof(argv[arg_idx++]);
+    }
+    else if (strcmp(arg, "--fixedstep") == 0)
+    {
+      udata->hfixed = atof(argv[arg_idx++]);
+    }
     else if (strcmp(arg, "--method") == 0)
     {
       udata->method = (ARKODE_LSRKMethodType)atoi(argv[arg_idx++]);
@@ -135,7 +147,10 @@ int ReadInputs(int argc, char** argv, UserData* udata)
       udata->eigsafety = atof(argv[arg_idx++]);
     }
     // Output settings
-    else if (strcmp(arg, "--nout") == 0) { udata->nout = atoi(argv[arg_idx++]); }
+    else if (strcmp(arg, "--nout") == 0)
+    {
+      udata->nout = atoi(argv[arg_idx++]);
+    }
     else if (strcmp(arg, "--wrms_norm_type") == 0)
     {
       udata->wrms_norm_type = atoi(argv[arg_idx++]);
@@ -145,8 +160,14 @@ int ReadInputs(int argc, char** argv, UserData* udata)
       udata->maxsteps = atoi(argv[arg_idx++]);
     }
     // DEE options
-    else if (strcmp(arg, "--user_dom_eig") == 0) { udata->user_dom_eig = SUNTRUE; }
-    else if (strcmp(arg, "--dee_id") == 0) { udata->dee_id = atoi(argv[arg_idx++]); }
+    else if (strcmp(arg, "--user_dom_eig") == 0)
+    {
+      udata->user_dom_eig = SUNTRUE;
+    }
+    else if (strcmp(arg, "--dee_id") == 0)
+    {
+      udata->dee_id = atoi(argv[arg_idx++]);
+    }
     else if (strcmp(arg, "--dee_num_init_wups") == 0)
     {
       udata->dee_num_init_wups = atoi(argv[arg_idx++]);
@@ -177,7 +198,8 @@ int ReadInputs(int argc, char** argv, UserData* udata)
     else
     {
       int isnum = isInteger(arg);
-      if (isnum == 0) {
+      if (isnum == 0)
+      {
         fprintf(stderr, "ERROR: Invalid input %s\n", arg);
         InputHelp();
         return -1;
@@ -193,27 +215,37 @@ void InputHelp(void)
 {
   printf("\n");
   printf("Command line options:\n");
-  printf("   -g                         : Run on GPUs if GPUs are present and code built for GPUs\n");
-  printf("   -M                         : Run with MPI if code built with MPI\n");
+  printf("   -g                         : Run on GPUs if GPUs are present and "
+         "code built for GPUs\n");
+  printf(
+    "   -M                         : Run with MPI if code built with MPI\n");
   printf("   -s <N>                     : Only run N steps of simulation\n");
-  printf("   -r <N>                     : Restart the simulation from frame N\n");
-  printf("   -o                         : Optional arguments (as string, requires parsing)\n");
+  printf(
+    "   -r <N>                     : Restart the simulation from frame N\n");
+  printf("   -o                         : Optional arguments (as string, "
+         "requires parsing)\n");
   printf("   -c <N>                     : Domain decomposition in x\n");
   printf("  --k <amplitude>             : diffusion amplitude\n");
   printf("  --tf <time>                 : final time\n");
   printf("  --rtol <rtol>               : relative tolerance\n");
   printf("  --atol <atol>               : absolute tolerance\n");
   printf("  --fixedstep <step>          : used fixed step size\n");
-  printf("  --wrms_norm_type <type>     : WRMS norm type (componentwise: 1, cellwise norm:2)\n");
-  printf("  --method <mth>              : LSRK method choice (0:RCK, 1:RKL, 2:SSP2, 3:SSP3, 4:SSP4)\n");
-  printf("  --eigfrequency <nst>        : dominant eigenvalue update frequency\n");
+  printf("  --wrms_norm_type <type>     : WRMS norm type (componentwise: 1, "
+         "cellwise norm:2)\n");
+  printf("  --method <mth>              : LSRK method choice (0:RCK, 1:RKL, "
+         "2:SSP2, 3:SSP3, 4:SSP4)\n");
+  printf(
+    "  --eigfrequency <nst>        : dominant eigenvalue update frequency\n");
   printf("  --stage_max_limit <smax>    : maximum number of stages per step\n");
-  printf("  --num_SSP_stages <nstages>  : number of stages in the SSP method\n");
+  printf(
+    "  --num_SSP_stages <nstages>  : number of stages in the SSP method\n");
   printf("  --eigsafety <safety>        : dominant eigenvalue safety factor\n");
   printf("  --nout <nout>               : number of outputs\n");
   printf("  --maxsteps <steps>          : max steps between outputs\n");
-  printf("  --user_dom_eig              : use user-provided dominant eigenvalue function\n");
-  printf("  --dee_id <id>               : DomEig Estimator (DEE) id (PI: 0, Arnoldi: 1)\n");
+  printf("  --user_dom_eig              : use user-provided dominant "
+         "eigenvalue function\n");
+  printf("  --dee_id <id>               : DomEig Estimator (DEE) id (PI: 0, "
+         "Arnoldi: 1)\n");
   printf("  --dee_num_init_wups <num>   : number of DEE initial warmups\n");
   printf("  --dee_num_succ_wups <num>   : number of DEE succeeding warmups\n");
   printf("  --dee_max_iters <num>       : max iterations in DEE\n");
@@ -225,7 +257,8 @@ void InputHelp(void)
 // Print user data
 int PrintUserData(UserData* udata, int rank)
 {
-  if (rank == 0) {
+  if (rank == 0)
+  {
     printf("\n");
     printf("gkeyll diffusion test problem:\n");
     printf(" ------------------------------------ \n");

--- a/gkeyll_diffusion/src/input_handler.c
+++ b/gkeyll_diffusion/src/input_handler.c
@@ -107,8 +107,6 @@ int ReadInputs(int argc, char** argv, UserData* udata)
     else if (strcmp(arg, "-r") == 0) { }
     else if (strcmp(arg, "-o") == 0) { }
     else if (strcmp(arg, "-c") == 0) { }
-    else if (strcmp(arg, "-d") == 0) { }
-    else if (strcmp(arg, "-e") == 0) { }
     // Diffusion parameters
     else if (strcmp(arg, "--k") == 0) { udata->k = atof(argv[arg_idx++]); }
     // Temporal domain settings
@@ -196,14 +194,12 @@ void InputHelp(void)
 {
   printf("\n");
   printf("Command line options:\n");
-  printf("  -g     Run on GPUs if GPUs are present and code built for GPUs\n");
-  printf("  -M     Run with MPI if code built with MPI\n");
-  printf("  -sN    Only run N steps of simulation\n");
-  printf("  -rN    Restart the simulation from frame N\n");
-  printf("  -o     Optional arguments (as string, requires parsing)\n");
-  printf("  -cPX Domain decomposition in x\n");
-  printf("  -dPY Domain decomposition in y\n");
-  printf("  -ePZ Domain decomposition in z\n");
+  printf("  -g   Run on GPUs if GPUs are present and code built for GPUs\n");
+  printf("  -M   Run with MPI if code built with MPI\n");
+  printf("  -s N Only run N steps of simulation\n");
+  printf("  -r N Restart the simulation from frame N\n");
+  printf("  -o   Optional arguments (as string, requires parsing)\n");
+  printf("  -c N Domain decomposition in x\n");
 
   printf("  --k <amplitude>             : diffusion amplitude\n");
   printf("  --tf <time>                 : final time\n");

--- a/gkeyll_diffusion/src/input_handler.c
+++ b/gkeyll_diffusion/src/input_handler.c
@@ -19,7 +19,6 @@
 
 #include "input_handler.h"
 #include <ctype.h>
-#include <stdbool.h>
 
 // -----------------------------------------------------------------------------
 // UserData and input functions
@@ -65,9 +64,9 @@ int InitUserData(UserData* udata)
 }
 
 // Function to check if a string is a valid integer
-bool isInteger(const char *str) {
+sunbooleantype isInteger(const char *str) {
     if (str == NULL || *str == '\0') { // Handle empty or NULL strings
-        return false;
+        return SUNFALSE;
     }
 
     // Handle optional leading sign
@@ -78,16 +77,16 @@ bool isInteger(const char *str) {
 
     // Check if there are any digits after the sign (if present)
     if (str[i] == '\0') {
-        return false; // Only a sign, no digits
+        return SUNFALSE; // Only a sign, no digits
     }
 
     // Iterate through the rest of the string
     for (; str[i] != '\0'; i++) {
         if (!isdigit(str[i])) {
-            return false; // Found a non-digit character
+            return SUNFALSE; // Found a non-digit character
         }
     }
-    return true; // All characters are digits (or a valid sign followed by digits)
+    return SUNTRUE; // All characters are digits (or a valid sign followed by digits)
 }
 
 // Read command line inputs
@@ -194,13 +193,12 @@ void InputHelp(void)
 {
   printf("\n");
   printf("Command line options:\n");
-  printf("  -g   Run on GPUs if GPUs are present and code built for GPUs\n");
-  printf("  -M   Run with MPI if code built with MPI\n");
-  printf("  -s N Only run N steps of simulation\n");
-  printf("  -r N Restart the simulation from frame N\n");
-  printf("  -o   Optional arguments (as string, requires parsing)\n");
-  printf("  -c N Domain decomposition in x\n");
-
+  printf("   -g                         : Run on GPUs if GPUs are present and code built for GPUs\n");
+  printf("   -M                         : Run with MPI if code built with MPI\n");
+  printf("   -s <N>                     : Only run N steps of simulation\n");
+  printf("   -r <N>                     : Restart the simulation from frame N\n");
+  printf("   -o                         : Optional arguments (as string, requires parsing)\n");
+  printf("   -c <N>                     : Domain decomposition in x\n");
   printf("  --k <amplitude>             : diffusion amplitude\n");
   printf("  --tf <time>                 : final time\n");
   printf("  --rtol <rtol>               : relative tolerance\n");
@@ -233,6 +231,7 @@ int PrintUserData(UserData* udata, int rank)
     printf(" ------------------------------------ \n");
     printf(" k                 = %g\n", udata->k);
     printf(" tf                = %g\n", udata->tf);
+    printf(" nout              = %d\n", udata->nout);
     printf(" ------------------------------------ \n");
     printf(" rtol              = %.2e\n", udata->rtol);
     printf(" atol              = %.2e\n", udata->atol);

--- a/gkeyll_diffusion/src/input_handler.h
+++ b/gkeyll_diffusion/src/input_handler.h
@@ -87,7 +87,7 @@ int ReadInputs(int argc, char** argv, UserData* udata);
 void InputHelp();
 
 // Print some UserData information
-int PrintUserData(UserData* udata);
+int PrintUserData(UserData* udata, int rank);
 
 // Print integration timing
 int OutputTiming(UserData* udata);

--- a/gkeyll_diffusion/src/input_handler.h
+++ b/gkeyll_diffusion/src/input_handler.h
@@ -79,6 +79,9 @@ int FreeUserData(UserData* udata);
 // Read the command line inputs and set UserData values
 int ReadInputs(int argc, char** argv, UserData* udata);
 
+// Function to check if an input string is a valid integer
+sunbooleantype isInteger(const char *str);
+
 // -----------------------------------------------------------------------------
 // Output and utility functions
 // -----------------------------------------------------------------------------

--- a/gkeyll_diffusion/src/input_handler.h
+++ b/gkeyll_diffusion/src/input_handler.h
@@ -39,11 +39,11 @@ typedef struct
   sunrealtype tf;
 
   // Integrator settings
-  sunrealtype rtol;           // relative tolerance
-  sunrealtype atol;           // absolute tolerance
-  sunrealtype hfixed;         // fixed step size
-  int maxsteps;               // max number of steps between outputs
-  int wrms_norm_type;         // wrms norm type (1:componentwise 2:cellwise)
+  sunrealtype rtol;   // relative tolerance
+  sunrealtype atol;   // absolute tolerance
+  sunrealtype hfixed; // fixed step size
+  int maxsteps;       // max number of steps between outputs
+  int wrms_norm_type; // wrms norm type (1:componentwise 2:cellwise)
 
   // LSRKStep options
   ARKODE_LSRKMethodType method; // LSRK method choice
@@ -53,11 +53,11 @@ typedef struct
   sunrealtype eigsafety;        // dominant eigenvalue safety factor
 
   // Output variables
-  int nout;       // number of output times
+  int nout; // number of output times
 
   // DEE options
   sunbooleantype user_dom_eig; // whether a user-provided dominant eigenvalue function is used
-  int dee_id;            // DEE ID (0: Power, 1: Arnoldi)
+  int dee_id;                  // DEE ID (0: Power, 1: Arnoldi)
   int dee_num_init_wups; // number of initial warmups before the first estimate
   int dee_num_succ_wups; // number of succeeding warmups before each estimate
   int dee_max_iters;     // max number of iterations
@@ -80,7 +80,7 @@ int FreeUserData(UserData* udata);
 int ReadInputs(int argc, char** argv, UserData* udata);
 
 // Function to check if an input string is a valid integer
-sunbooleantype isInteger(const char *str);
+sunbooleantype isInteger(const char* str);
 
 // -----------------------------------------------------------------------------
 // Output and utility functions

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -210,7 +210,7 @@ void N_VLinearSum_Gkylzero(sunrealtype a, N_Vector x, sunrealtype b, N_Vector y,
   struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* ydptr = NV_CONTENT_GKZ(y)->dataptr;
   struct gkyl_array* zdptr = NV_CONTENT_GKZ(z)->dataptr;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(z)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
 
   gkyl_array_comp_op_range(zdptr, GKYL_AXPBY, a, xdptr, b, ydptr, local_range);
 }
@@ -227,7 +227,7 @@ void N_VScale_Gkylzero(sunrealtype c, N_Vector x, N_Vector z)
 {
   struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* zdptr = NV_CONTENT_GKZ(z)->dataptr;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(z)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
 
   gkyl_array_set_range(zdptr, c, xdptr, local_range);
 }
@@ -237,7 +237,7 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
   struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* wdptr       = NV_CONTENT_GKZ(w)->dataptr;
   struct gkyl_comm* comm         = NV_CONTENT_GKZ(w)->comm;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
   bool use_gpu                   = NV_CONTENT_GKZ(w)->use_gpu;
 
   // TODO: change code so these allocations only happen once.
@@ -291,7 +291,7 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
   struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* wdptr       = NV_CONTENT_GKZ(w)->dataptr;
   struct gkyl_comm* comm         = NV_CONTENT_GKZ(w)->comm;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
 
   // TODO: change code so these allocations only happen once.
   int ncomp      = xdptr->ncomp;
@@ -340,7 +340,7 @@ sunrealtype N_VDotProd_Gkylzero(N_Vector x, N_Vector y)
   struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
   struct gkyl_array* ydptr       = NV_CONTENT_GKZ(y)->dataptr;
   struct gkyl_comm* comm         = NV_CONTENT_GKZ(y)->comm;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(y)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
   bool use_gpu                   = NV_CONTENT_GKZ(y)->use_gpu;
 
   struct gkyl_array* ztmp; // Temporary buffer. Should change code to avoid this.
@@ -400,7 +400,7 @@ void N_VDiv_Gkylzero(N_Vector u, N_Vector v, N_Vector w)
   struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
   struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
   struct gkyl_array* wdptr = NV_CONTENT_GKZ(w)->dataptr;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(u)->local_range;
 
   /* SUN_RCONST(1.0) values are unused dummy variables */
   gkyl_array_comp_op_range(wdptr, GKYL_DIV, SUN_RCONST(1.0), udptr, SUN_RCONST(0.0),
@@ -482,7 +482,7 @@ void N_VAddconst_Gkylzero(N_Vector u, sunrealtype x, N_Vector v)
 {
   struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
   struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
-  struct gkyl_range* local_range = NV_CONTENT_GKZ(v)->local_range;
+  struct gkyl_range* local_range = NV_CONTENT_GKZ(u)->local_range;
 
   gkyl_array_copy_range(vdptr, udptr, local_range);
 

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -229,13 +229,11 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
   struct gkyl_array* zdptr; // Temporary buffer. Should change code to avoid this.
   double* asum_ho = gkyl_malloc(ncomp * sizeof(double));
   double* asum;
-  if (gkyl_array_is_cu_dev(xdptr))
-  {
+  if (gkyl_array_is_cu_dev(xdptr)) {
     asum  = gkyl_cu_malloc(ncomp * sizeof(double));
     zdptr = mkarr(true, ncomp, xdptr->size);
   }
-  else
-  {
+  else {
     asum  = gkyl_malloc(ncomp * sizeof(double));
     zdptr = mkarr(false, ncomp, xdptr->size);
   }
@@ -245,17 +243,21 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
 
   if (gkyl_array_is_cu_dev(xdptr))
     gkyl_cu_memcpy(asum_ho, asum, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else memcpy(asum_ho, asum, ncomp * sizeof(double));
+  else
+    memcpy(asum_ho, asum, ncomp * sizeof(double));
 
   // Sum over compontents, divide by number degrees of freedom and take sqrt.
   sunrealtype asum_out = 0.0;
-  for (int i = 0; i < ncomp; i++) asum_out += asum_ho[i];
+  for (int i = 0; i < ncomp; i++)
+    asum_out += asum_ho[i];
 
   asum_out = SUNRsqrt(asum_out / (xdptr->size * ncomp));
 
   gkyl_free(asum_ho);
-  if (gkyl_array_is_cu_dev(xdptr)) gkyl_cu_free(asum);
-  else gkyl_free(asum);
+  if (gkyl_array_is_cu_dev(xdptr))
+    gkyl_cu_free(asum);
+  else
+    gkyl_free(asum);
 
   gkyl_array_release(zdptr);
 
@@ -271,24 +273,31 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
   int ncomp      = xdptr->ncomp;
   double* red_ho = gkyl_malloc(ncomp * sizeof(double));
   double* red;
-  if (gkyl_array_is_cu_dev(xdptr)) red = gkyl_cu_malloc(ncomp * sizeof(double));
-  else red = gkyl_malloc(ncomp * sizeof(double));
+  if (gkyl_array_is_cu_dev(xdptr))
+    red = gkyl_cu_malloc(ncomp * sizeof(double));
+  else
+    red = gkyl_malloc(ncomp * sizeof(double));
 
   // Reduce over cells.
   gkyl_array_reduce_weighted(red, xdptr, wdptr, GKYL_SQ_SUM);
 
   if (gkyl_array_is_cu_dev(xdptr))
     gkyl_cu_memcpy(red_ho, red, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else memcpy(red_ho, red, ncomp * sizeof(double));
+  else
+    memcpy(red_ho, red, ncomp * sizeof(double));
 
   // Reduce over components.
   sunrealtype red_out = 0.0;
-  for (sunindextype i = 0; i < ncomp; ++i) { red_out += red_ho[i]; }
+  for (sunindextype i = 0; i < ncomp; ++i)
+    red_out += red_ho[i];
+
   red_out = SUNRsqrt(red_out / xdptr->size);
 
   gkyl_free(red_ho);
-  if (gkyl_array_is_cu_dev(xdptr)) gkyl_cu_free(red);
-  else gkyl_free(red);
+  if (gkyl_array_is_cu_dev(xdptr))
+    gkyl_cu_free(red);
+  else
+    gkyl_free(red);
 
   return red_out;
 }
@@ -363,23 +372,25 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   double* red;
   if (gkyl_array_is_cu_dev(udptr))
     red = gkyl_cu_malloc(udptr->ncomp * sizeof(double));
-  else red = gkyl_malloc(udptr->ncomp * sizeof(double));
+  else
+    red = gkyl_malloc(udptr->ncomp * sizeof(double));
 
   gkyl_array_reduce(red, udptr, GKYL_ABS_MAX);
 
   if (gkyl_array_is_cu_dev(udptr))
     gkyl_cu_memcpy(red_ho, red, udptr->ncomp * sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
-  else memcpy(red_ho, red, udptr->ncomp * sizeof(double));
+  else
+    memcpy(red_ho, red, udptr->ncomp * sizeof(double));
 
   sunrealtype max = 0.0;
   for (sunindextype i = 0; i < udptr->ncomp; ++i)
-  {
     max = fmax(max, red_ho[i]);
-  }
 
-  if (gkyl_array_is_cu_dev(udptr)) gkyl_cu_free(red);
-  else gkyl_free(red);
+  if (gkyl_array_is_cu_dev(udptr))
+    gkyl_cu_free(red);
+  else
+    gkyl_free(red);
 
   return (max);
 }
@@ -393,7 +404,8 @@ void N_VAddconst_Gkylzero(N_Vector u, sunrealtype x, N_Vector v)
 
   sunindextype N = udptr->ncomp;
 
-  for (sunindextype i = 0; i < N; ++i) { gkyl_array_shiftc(vdptr, x, i); }
+  for (sunindextype i = 0; i < N; ++i)
+    gkyl_array_shiftc(vdptr, x, i);
 
   return;
 }

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -470,12 +470,12 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_MAX, ncomp, red_local, red_global);
 
   if (use_gpu)
-    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
-                   GKYL_CU_MEMCPY_D2H);
-  else memcpy(red_ho, red_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
+  else
+    memcpy(red_ho, red_global, ncomp * sizeof(double));
 
-  sunrealtype max = 0.0;
-  for (sunindextype i = 0; i < ncomp; ++i) max = fmax(max, red_ho[i]);
+  sunrealtype u_abs_max = -1.0;
+  for (sunindextype i = 0; i < ncomp; ++i) u_abs_max = fmax(u_abs_max, red_ho[i]);
 
   if (use_gpu)
   {
@@ -488,7 +488,7 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
     gkyl_free(red_global);
   }
 
-  return (max);
+  return u_abs_max;
 }
 
 void N_VAddconst_Gkylzero(N_Vector u, sunrealtype x, N_Vector v)

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -83,7 +83,8 @@ N_Vector N_VNewEmpty_Gkylzero(SUNContext sunctx)
 
 /* Create a Gkylzero N_Vector wrapper around user supplied gkl_array. */
 N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu,
-  struct gkyl_comm *comm, struct gkyl_range *local_range, SUNContext sunctx)
+                          struct gkyl_comm* comm,
+                          struct gkyl_range* local_range, SUNContext sunctx)
 {
   N_Vector v;
   v = NULL;
@@ -205,9 +206,9 @@ void N_VDestroy_Gkylzero(N_Vector v)
 void N_VLinearSum_Gkylzero(sunrealtype a, N_Vector x, sunrealtype b, N_Vector y,
                            N_Vector z)
 {
-  struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
-  struct gkyl_array* ydptr = NV_CONTENT_GKZ(y)->dataptr;
-  struct gkyl_array* zdptr = NV_CONTENT_GKZ(z)->dataptr;
+  struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
+  struct gkyl_array* ydptr       = NV_CONTENT_GKZ(y)->dataptr;
+  struct gkyl_array* zdptr       = NV_CONTENT_GKZ(z)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(z)->local_range;
 
   gkyl_array_comp_op_range(zdptr, GKYL_AXPBY, a, xdptr, b, ydptr, local_range);
@@ -215,7 +216,7 @@ void N_VLinearSum_Gkylzero(sunrealtype a, N_Vector x, sunrealtype b, N_Vector y,
 
 void N_VConst_Gkylzero(sunrealtype c, N_Vector z)
 {
-  struct gkyl_array* zdptr = NV_CONTENT_GKZ(z)->dataptr;
+  struct gkyl_array* zdptr       = NV_CONTENT_GKZ(z)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(z)->local_range;
 
   gkyl_array_clear_range(zdptr, c, local_range);
@@ -223,8 +224,8 @@ void N_VConst_Gkylzero(sunrealtype c, N_Vector z)
 
 void N_VScale_Gkylzero(sunrealtype c, N_Vector x, N_Vector z)
 {
-  struct gkyl_array* xdptr = NV_CONTENT_GKZ(x)->dataptr;
-  struct gkyl_array* zdptr = NV_CONTENT_GKZ(z)->dataptr;
+  struct gkyl_array* xdptr       = NV_CONTENT_GKZ(x)->dataptr;
+  struct gkyl_array* zdptr       = NV_CONTENT_GKZ(z)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(z)->local_range;
 
   gkyl_array_set_range(zdptr, c, xdptr, local_range);
@@ -241,41 +242,45 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
   // TODO: change code so these allocations only happen once.
   int ncomp = xdptr->ncomp;
   struct gkyl_array* zdptr; // Temporary buffer. Should change code to avoid this.
-  zdptr = mkarr(use_gpu, ncomp, xdptr->size);
+  zdptr           = mkarr(use_gpu, ncomp, xdptr->size);
   double* asum_ho = gkyl_malloc(ncomp * sizeof(double));
   double *asum_local, *asum_global;
-  if (gkyl_array_is_cu_dev(xdptr)) {
+  if (gkyl_array_is_cu_dev(xdptr))
+  {
     asum_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     asum_global = gkyl_cu_malloc(ncomp * sizeof(double));
   }
-  else {
+  else
+  {
     asum_local  = gkyl_malloc(ncomp * sizeof(double));
     asum_global = gkyl_malloc(ncomp * sizeof(double));
   }
 
   gkyl_array_comp_op_range(zdptr, GKYL_PROD, 1.0, xdptr, 0.0, wdptr, local_range);
   gkyl_array_reduce_range(asum_local, zdptr, GKYL_SQ_SUM, local_range);
-  gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, asum_local, asum_global);
+  gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, asum_local,
+                      asum_global);
 
   if (gkyl_array_is_cu_dev(xdptr))
-    gkyl_cu_memcpy(asum_ho, asum_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else
-    memcpy(asum_ho, asum_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(asum_ho, asum_global, ncomp * sizeof(double),
+                   GKYL_CU_MEMCPY_D2H);
+  else memcpy(asum_ho, asum_global, ncomp * sizeof(double));
 
   // Sum over compontents, divide by number degrees of freedom and take sqrt.
   sunrealtype asum_out = 0.0;
-  for (int i = 0; i < ncomp; i++)
-    asum_out += asum_ho[i];
+  for (int i = 0; i < ncomp; i++) asum_out += asum_ho[i];
 
   asum_out = SUNRsqrt(asum_out / (xdptr->size * ncomp));
 
   gkyl_free(asum_ho);
-  if (gkyl_array_is_cu_dev(xdptr)) {
-    gkyl_cu_free(asum_local );
+  if (gkyl_array_is_cu_dev(xdptr))
+  {
+    gkyl_cu_free(asum_local);
     gkyl_cu_free(asum_global);
   }
-  else {
-    gkyl_free(asum_local );
+  else
+  {
+    gkyl_free(asum_local);
     gkyl_free(asum_global);
   }
 
@@ -295,38 +300,42 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
   int ncomp      = xdptr->ncomp;
   double* red_ho = gkyl_malloc(ncomp * sizeof(double));
   double *red_local, *red_global;
-  if (gkyl_array_is_cu_dev(xdptr)) {
+  if (gkyl_array_is_cu_dev(xdptr))
+  {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
   }
-  else {
+  else
+  {
     red_local  = gkyl_malloc(ncomp * sizeof(double));
     red_global = gkyl_malloc(ncomp * sizeof(double));
   }
 
   // Reduce over cells.
-  gkyl_array_reduce_weighted_range(red_local, xdptr, wdptr, GKYL_SQ_SUM, local_range);
+  gkyl_array_reduce_weighted_range(red_local, xdptr, wdptr, GKYL_SQ_SUM,
+                                   local_range);
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, red_local, red_global);
 
   if (gkyl_array_is_cu_dev(xdptr))
-    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else
-    memcpy(red_ho, red_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
+                   GKYL_CU_MEMCPY_D2H);
+  else memcpy(red_ho, red_global, ncomp * sizeof(double));
 
   // Reduce over components.
   sunrealtype red_out = 0.0;
-  for (sunindextype i = 0; i < ncomp; ++i)
-    red_out += red_ho[i];
+  for (sunindextype i = 0; i < ncomp; ++i) red_out += red_ho[i];
 
   red_out = SUNRsqrt(red_out / xdptr->size);
 
   gkyl_free(red_ho);
-  if (gkyl_array_is_cu_dev(xdptr)) {
-    gkyl_cu_free(red_local );
+  if (gkyl_array_is_cu_dev(xdptr))
+  {
+    gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);
   }
-  else {
-    gkyl_free(red_local );
+  else
+  {
+    gkyl_free(red_local);
     gkyl_free(red_global);
   }
 
@@ -344,19 +353,22 @@ sunrealtype N_VDotProd_Gkylzero(N_Vector x, N_Vector y)
   struct gkyl_array* ztmp; // Temporary buffer. Should change code to avoid this.
   ztmp = mkarr(use_gpu, xdptr->ncomp, xdptr->size);
 
-  // z_i^{(k)} = x_i^{(k)} * y_i^{(k)}  
-  gkyl_array_comp_op_range(ztmp, GKYL_PROD, SUN_RCONST(1.0), ydptr, SUN_RCONST(0.0), xdptr, local_range);
+  // z_i^{(k)} = x_i^{(k)} * y_i^{(k)}
+  gkyl_array_comp_op_range(ztmp, GKYL_PROD, SUN_RCONST(1.0), ydptr,
+                           SUN_RCONST(0.0), xdptr, local_range);
 
   // Sum reduce x (component-wise).
   // TODO: change code so these allocations only happen once.
   int ncomp = xdptr->ncomp;
   sunrealtype red_ho[ncomp];
   double *red_local, *red_global;
-  if (use_gpu) {
+  if (use_gpu)
+  {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
   }
-  else {
+  else
+  {
     red_local  = gkyl_malloc(ncomp * sizeof(double));
     red_global = gkyl_malloc(ncomp * sizeof(double));
   }
@@ -365,20 +377,21 @@ sunrealtype N_VDotProd_Gkylzero(N_Vector x, N_Vector y)
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, red_local, red_global);
 
   if (gkyl_array_is_cu_dev(xdptr))
-    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else
-    memcpy(red_ho, red_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
+                   GKYL_CU_MEMCPY_D2H);
+  else memcpy(red_ho, red_global, ncomp * sizeof(double));
 
   sunrealtype dot_prod = 0.0;
-  for (sunindextype i = 0; i < ncomp; ++i)
-    dot_prod += red_ho[i];
+  for (sunindextype i = 0; i < ncomp; ++i) dot_prod += red_ho[i];
 
-  if (use_gpu) {
-    gkyl_cu_free(red_local );
+  if (use_gpu)
+  {
+    gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);
   }
-  else {
-    gkyl_free(red_local );
+  else
+  {
+    gkyl_free(red_local);
     gkyl_free(red_global);
   }
   gkyl_array_release(ztmp);
@@ -395,40 +408,40 @@ void N_VSpace_Gkylzero(N_Vector v, sunindextype* x, sunindextype* y)
 
 void N_VDiv_Gkylzero(N_Vector u, N_Vector v, N_Vector w)
 {
-  struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
-  struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
-  struct gkyl_array* wdptr = NV_CONTENT_GKZ(w)->dataptr;
+  struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
+  struct gkyl_array* vdptr       = NV_CONTENT_GKZ(v)->dataptr;
+  struct gkyl_array* wdptr       = NV_CONTENT_GKZ(w)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(w)->local_range;
 
   /* SUN_RCONST(1.0) values are unused dummy variables */
-  gkyl_array_comp_op_range(wdptr, GKYL_DIV, SUN_RCONST(1.0), udptr, SUN_RCONST(0.0),
-    vdptr, local_range);
+  gkyl_array_comp_op_range(wdptr, GKYL_DIV, SUN_RCONST(1.0), udptr,
+                           SUN_RCONST(0.0), vdptr, local_range);
 
   return;
 }
 
 void N_VAbs_Gkylzero(N_Vector u, N_Vector v)
 {
-  struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
-  struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
+  struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
+  struct gkyl_array* vdptr       = NV_CONTENT_GKZ(v)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(u)->local_range;
 
   /* SUN_RCONST(1.0) values and the last vdptr pointer are unused dummy variables */
-  gkyl_array_comp_op_range(vdptr, GKYL_ABS, SUN_RCONST(1.0), udptr, SUN_RCONST(1.0),
-    vdptr, local_range);
+  gkyl_array_comp_op_range(vdptr, GKYL_ABS, SUN_RCONST(1.0), udptr,
+                           SUN_RCONST(1.0), vdptr, local_range);
 
   return;
 }
 
 void N_VInv_Gkylzero(N_Vector u, N_Vector v)
 {
-  struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
-  struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
+  struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
+  struct gkyl_array* vdptr       = NV_CONTENT_GKZ(v)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(u)->local_range;
 
   /* SUN_RCONST(1.0) values and the last vdptr pointer are unused dummy variables */
-  gkyl_array_comp_op_range(vdptr, GKYL_INV, SUN_RCONST(1.0), udptr, SUN_RCONST(1.0),
-    vdptr, local_range);
+  gkyl_array_comp_op_range(vdptr, GKYL_INV, SUN_RCONST(1.0), udptr,
+                           SUN_RCONST(1.0), vdptr, local_range);
 
   return;
 }
@@ -443,11 +456,13 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   int ncomp = udptr->ncomp;
   sunrealtype red_ho[ncomp];
   double *red_local, *red_global;
-  if (gkyl_array_is_cu_dev(udptr)) {
+  if (gkyl_array_is_cu_dev(udptr))
+  {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
   }
-  else {
+  else
+  {
     red_local  = gkyl_malloc(ncomp * sizeof(double));
     red_global = gkyl_malloc(ncomp * sizeof(double));
   }
@@ -456,20 +471,21 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_MAX, ncomp, red_local, red_global);
 
   if (gkyl_array_is_cu_dev(udptr))
-    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double), GKYL_CU_MEMCPY_D2H);
-  else
-    memcpy(red_ho, red_global, ncomp * sizeof(double));
+    gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
+                   GKYL_CU_MEMCPY_D2H);
+  else memcpy(red_ho, red_global, ncomp * sizeof(double));
 
   sunrealtype max = 0.0;
-  for (sunindextype i = 0; i < ncomp; ++i)
-    max = fmax(max, red_ho[i]);
+  for (sunindextype i = 0; i < ncomp; ++i) max = fmax(max, red_ho[i]);
 
-  if (gkyl_array_is_cu_dev(udptr)) {
-    gkyl_cu_free(red_local );
+  if (gkyl_array_is_cu_dev(udptr))
+  {
+    gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);
   }
-  else {
-    gkyl_free(red_local );
+  else
+  {
+    gkyl_free(red_local);
     gkyl_free(red_global);
   }
 
@@ -478,8 +494,8 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
 
 void N_VAddconst_Gkylzero(N_Vector u, sunrealtype x, N_Vector v)
 {
-  struct gkyl_array* udptr = NV_CONTENT_GKZ(u)->dataptr;
-  struct gkyl_array* vdptr = NV_CONTENT_GKZ(v)->dataptr;
+  struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
+  struct gkyl_array* vdptr       = NV_CONTENT_GKZ(v)->dataptr;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(v)->local_range;
 
   gkyl_array_copy_range(vdptr, udptr, local_range);

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -23,10 +23,8 @@ struct gkyl_array* mkarr(bool on_gpu, long nc, long size)
 {
   // Allocate array (filled with zeros).
   struct gkyl_array* a;
-  if (on_gpu)
-    a = gkyl_array_cu_dev_new(GKYL_DOUBLE, nc, size);
-  else
-    a = gkyl_array_new(GKYL_DOUBLE, nc, size);
+  if (on_gpu) a = gkyl_array_cu_dev_new(GKYL_DOUBLE, nc, size);
+  else a = gkyl_array_new(GKYL_DOUBLE, nc, size);
   return a;
 }
 

--- a/gkeyll_diffusion/src/nvector_gkylzero.c
+++ b/gkeyll_diffusion/src/nvector_gkylzero.c
@@ -241,11 +241,9 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
 
   // TODO: change code so these allocations only happen once.
   int ncomp = xdptr->ncomp;
-  struct gkyl_array* zdptr; // Temporary buffer. Should change code to avoid this.
-  zdptr           = mkarr(use_gpu, ncomp, xdptr->size);
   double* asum_ho = gkyl_malloc(ncomp * sizeof(double));
   double *asum_local, *asum_global;
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
   {
     asum_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     asum_global = gkyl_cu_malloc(ncomp * sizeof(double));
@@ -255,13 +253,14 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
     asum_local  = gkyl_malloc(ncomp * sizeof(double));
     asum_global = gkyl_malloc(ncomp * sizeof(double));
   }
+  struct gkyl_array* zdptr = mkarr(use_gpu, ncomp, xdptr->size); // Temporary buffer. Should change code to avoid this.
 
   gkyl_array_comp_op_range(zdptr, GKYL_PROD, 1.0, xdptr, 0.0, wdptr, local_range);
   gkyl_array_reduce_range(asum_local, zdptr, GKYL_SQ_SUM, local_range);
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, asum_local,
                       asum_global);
 
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
     gkyl_cu_memcpy(asum_ho, asum_global, ncomp * sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
   else memcpy(asum_ho, asum_global, ncomp * sizeof(double));
@@ -270,10 +269,10 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
   sunrealtype asum_out = 0.0;
   for (int i = 0; i < ncomp; i++) asum_out += asum_ho[i];
 
-  asum_out = SUNRsqrt(asum_out / (xdptr->size * ncomp));
+  asum_out = SUNRsqrt(asum_out / (local_range->volume * ncomp));
 
   gkyl_free(asum_ho);
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
   {
     gkyl_cu_free(asum_local);
     gkyl_cu_free(asum_global);
@@ -283,7 +282,6 @@ sunrealtype N_VWrmsNorm_abs_comp_Gkylzero(N_Vector x, N_Vector w)
     gkyl_free(asum_local);
     gkyl_free(asum_global);
   }
-
   gkyl_array_release(zdptr);
 
   return asum_out;
@@ -295,12 +293,13 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
   struct gkyl_array* wdptr       = NV_CONTENT_GKZ(w)->dataptr;
   struct gkyl_comm* comm         = NV_CONTENT_GKZ(w)->comm;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(x)->local_range;
+  bool use_gpu                   = NV_CONTENT_GKZ(x)->use_gpu;
 
   // TODO: change code so these allocations only happen once.
   int ncomp      = xdptr->ncomp;
   double* red_ho = gkyl_malloc(ncomp * sizeof(double));
   double *red_local, *red_global;
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
   {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
@@ -316,7 +315,7 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
                                    local_range);
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, red_local, red_global);
 
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
     gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
   else memcpy(red_ho, red_global, ncomp * sizeof(double));
@@ -325,10 +324,10 @@ sunrealtype N_VWrmsNorm_cell_norm_Gkylzero(N_Vector x, N_Vector w)
   sunrealtype red_out = 0.0;
   for (sunindextype i = 0; i < ncomp; ++i) red_out += red_ho[i];
 
-  red_out = SUNRsqrt(red_out / xdptr->size);
+  red_out = SUNRsqrt(red_out / local_range->volume);
 
   gkyl_free(red_ho);
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
   {
     gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);
@@ -376,7 +375,7 @@ sunrealtype N_VDotProd_Gkylzero(N_Vector x, N_Vector y)
   gkyl_array_reduce_range(red_local, ztmp, GKYL_SUM, local_range);
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_SUM, ncomp, red_local, red_global);
 
-  if (gkyl_array_is_cu_dev(xdptr))
+  if (use_gpu)
     gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
   else memcpy(red_ho, red_global, ncomp * sizeof(double));
@@ -446,17 +445,17 @@ void N_VInv_Gkylzero(N_Vector u, N_Vector v)
   return;
 }
 
-//use gkyl_array_comp_op!
 sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
 {
   struct gkyl_array* udptr       = NV_CONTENT_GKZ(u)->dataptr;
   struct gkyl_comm* comm         = NV_CONTENT_GKZ(u)->comm;
   struct gkyl_range* local_range = NV_CONTENT_GKZ(u)->local_range;
+  bool use_gpu                   = NV_CONTENT_GKZ(u)->use_gpu;
 
   int ncomp = udptr->ncomp;
   sunrealtype red_ho[ncomp];
   double *red_local, *red_global;
-  if (gkyl_array_is_cu_dev(udptr))
+  if (use_gpu)
   {
     red_local  = gkyl_cu_malloc(ncomp * sizeof(double));
     red_global = gkyl_cu_malloc(ncomp * sizeof(double));
@@ -470,7 +469,7 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   gkyl_array_reduce_range(red_local, udptr, GKYL_ABS_MAX, local_range);
   gkyl_comm_allreduce(comm, GKYL_DOUBLE, GKYL_MAX, ncomp, red_local, red_global);
 
-  if (gkyl_array_is_cu_dev(udptr))
+  if (use_gpu)
     gkyl_cu_memcpy(red_ho, red_global, ncomp * sizeof(double),
                    GKYL_CU_MEMCPY_D2H);
   else memcpy(red_ho, red_global, ncomp * sizeof(double));
@@ -478,7 +477,7 @@ sunrealtype N_VMaxnorm_Gkylzero(N_Vector u)
   sunrealtype max = 0.0;
   for (sunindextype i = 0; i < ncomp; ++i) max = fmax(max, red_ho[i]);
 
-  if (gkyl_array_is_cu_dev(udptr))
+  if (use_gpu)
   {
     gkyl_cu_free(red_local);
     gkyl_cu_free(red_global);

--- a/gkeyll_diffusion/src/nvector_gkylzero.h
+++ b/gkeyll_diffusion/src/nvector_gkylzero.h
@@ -22,8 +22,11 @@
 #include <gkyl_array_reduce.h>
 
 #ifdef GKYL_HAVE_MPI
-#include <gkyl_mpi_comm.h>
 #include <mpi.h>
+#include <gkyl_mpi_comm.h>
+#ifdef GKYL_HAVE_NCCL
+#include <gkyl_nccl_comm.h>
+#endif
 #endif
 
 #define NV_CONTENT_GKZ(v) ((N_VectorContent_Gkylzero)(v->content))

--- a/gkeyll_diffusion/src/nvector_gkylzero.h
+++ b/gkeyll_diffusion/src/nvector_gkylzero.h
@@ -22,8 +22,8 @@
 #include <gkyl_array_reduce.h>
 
 #ifdef GKYL_HAVE_MPI
-#include <mpi.h>
 #include <gkyl_mpi_comm.h>
+#include <mpi.h>
 #ifdef GKYL_HAVE_NCCL
 #include <gkyl_nccl_comm.h>
 #endif
@@ -41,12 +41,12 @@ extern "C" {
 
 struct _N_VectorContent_Gkylzero
 {
-  sunbooleantype own_vector;  /* ownership Gkylzero vector */
-  sunbooleantype use_gpu;     /* where to reside */
+  sunbooleantype own_vector; /* ownership Gkylzero vector */
+  sunbooleantype use_gpu;    /* where to reside */
   // Gkeyll pointers.
-  struct gkyl_comm *comm; // Communicator.
-  struct gkyl_range *local_range; // Local range.
-  struct gkyl_array *dataptr; // Data of this array/vector.
+  struct gkyl_comm* comm;         // Communicator.
+  struct gkyl_range* local_range; // Local range.
+  struct gkyl_array* dataptr;     // Data of this array/vector.
 };
 
 typedef struct _N_VectorContent_Gkylzero* N_VectorContent_Gkylzero;
@@ -57,8 +57,9 @@ typedef struct _N_VectorContent_Gkylzero* N_VectorContent_Gkylzero;
 struct gkyl_array* mkarr(bool on_gpu, long nc, long size);
 
 N_Vector N_VNewEmpty_Gkylzero(SUNContext sunctx);
-N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu, struct gkyl_comm *comm,
-                          struct gkyl_range *local_range, SUNContext sunctx);
+N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu,
+                          struct gkyl_comm* comm,
+                          struct gkyl_range* local_range, SUNContext sunctx);
 struct gkyl_array* N_VGetVector_Gkylzero(N_Vector v);
 
 N_Vector N_VCloneEmpty_Gkylzero(N_Vector w);

--- a/gkeyll_diffusion/src/nvector_gkylzero.h
+++ b/gkeyll_diffusion/src/nvector_gkylzero.h
@@ -43,8 +43,9 @@ struct _N_VectorContent_Gkylzero
 {
   sunbooleantype own_vector;  /* ownership Gkylzero vector */
   sunbooleantype use_gpu;     /* where to reside */
-  struct gkyl_array* dataptr; /* the actual Gkylzero object pointer */
-  /* TODO: ADD GKYL COMMUNICATOR */
+  // Gkeyll pointers.
+  struct gkyl_comm *comm; // Communicator.
+  struct gkyl_array *dataptr; // Data of this array/vector.
 };
 
 typedef struct _N_VectorContent_Gkylzero* N_VectorContent_Gkylzero;
@@ -55,7 +56,7 @@ typedef struct _N_VectorContent_Gkylzero* N_VectorContent_Gkylzero;
 struct gkyl_array* mkarr(bool on_gpu, long nc, long size);
 
 N_Vector N_VNewEmpty_Gkylzero(SUNContext sunctx);
-N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu,
+N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu, struct gkyl_comm *comm,
                           SUNContext sunctx);
 struct gkyl_array* N_VGetVector_Gkylzero(N_Vector v);
 

--- a/gkeyll_diffusion/src/nvector_gkylzero.h
+++ b/gkeyll_diffusion/src/nvector_gkylzero.h
@@ -45,6 +45,7 @@ struct _N_VectorContent_Gkylzero
   sunbooleantype use_gpu;     /* where to reside */
   // Gkeyll pointers.
   struct gkyl_comm *comm; // Communicator.
+  struct gkyl_range *local_range; // Local range.
   struct gkyl_array *dataptr; // Data of this array/vector.
 };
 
@@ -57,7 +58,7 @@ struct gkyl_array* mkarr(bool on_gpu, long nc, long size);
 
 N_Vector N_VNewEmpty_Gkylzero(SUNContext sunctx);
 N_Vector N_VMake_Gkylzero(struct gkyl_array* x, sunbooleantype use_gpu, struct gkyl_comm *comm,
-                          SUNContext sunctx);
+                          struct gkyl_range *local_range, SUNContext sunctx);
 struct gkyl_array* N_VGetVector_Gkylzero(N_Vector v);
 
 N_Vector N_VCloneEmpty_Gkylzero(N_Vector w);

--- a/gkeyll_diffusion/test_nvector_gkylzero.c
+++ b/gkeyll_diffusion/test_nvector_gkylzero.c
@@ -1,5 +1,5 @@
-#include "src/nvector_gkylzero.h"
 #include <gkyl_null_comm.h>
+#include "src/nvector_gkylzero.h"
 
 void test_NVector(bool use_gpu)
 {
@@ -13,10 +13,8 @@ void test_NVector(bool use_gpu)
   gkyl_range_init(&local, 1, lower, upper);
 
   // Construct communicator for use in app.
-  struct gkyl_comm *comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) {
-      .use_gpu = use_gpu
-    }
-  );
+  struct gkyl_comm* comm =
+    gkyl_null_comm_inew(&(struct gkyl_null_comm_inp){.use_gpu = use_gpu});
 
   printf("\nTESTING nvector_gkylzero:\n");
 
@@ -153,8 +151,8 @@ void test_NVector(bool use_gpu)
   struct gkyl_array* v2      = mkarr(use_gpu, num_basis, local.volume);
   struct gkyl_array* lin_sum = mkarr(use_gpu, num_basis, local.volume);
 
-  N_Vector Nv1      = N_VMake_Gkylzero(v1     , use_gpu, comm, &local, sunctx);
-  N_Vector Nv2      = N_VMake_Gkylzero(v2     , use_gpu, comm, &local, sunctx);
+  N_Vector Nv1      = N_VMake_Gkylzero(v1, use_gpu, comm, &local, sunctx);
+  N_Vector Nv2      = N_VMake_Gkylzero(v2, use_gpu, comm, &local, sunctx);
   N_Vector Nlin_sum = N_VMake_Gkylzero(lin_sum, use_gpu, comm, &local, sunctx);
 
   N_VConst_Gkylzero(c, Nv1);


### PR DESCRIPTION
Changes
---------
This PR:
1. Fixes the GPU build, at least on Princeton's Stellar AMD cluster.
2. Makes the changes necessary for the gkeyll_diffusion program to work on multiple CPUs and GPUs (not finished, see below).

Important:
-----------
in the process of doing 2, we made it so that all operations are performed in physical cells only (the `local` range), not the ghost cells. The ghost cells are only used in two places:
- In applying periodic BCs.
- In applying the DG diffusion operation in the cells near the boundaries.

Now the reported error appears to be inline with the requested tolerance.

Not finished
------------
The code doesn't yet behave well when running on 2 CPUs. With the default settings running on 1 CPU we get this output:
```
[manaurer@stellar-amd gkeyll_diffusion]$ ./gk_diffusion_1x1v_p1

gkeyll diffusion test problem:
 ------------------------------------
 k                 = 0.1
 tf                = 1
 ------------------------------------
 rtol              = 1.00e-05
 atol              = 1.00e-12
 hfixed            = 0.00e+00
 method            = 1
 eigfrequency      = 0
 stage_max_limit   = 200
 num SSP stages    = 4
 eigsafety         = 1.01
 ------------------------------------
 wrms norm type    = 2
 max steps         = 100000
 ------------------------------------
 dom_eig provided  = 0
 dee ID            = 0
 dee num_init_wups = 100
 dee num_succ_wups = 0
 dee_max_iters     = 1000
 dee_krylov_dim    = 3
 dee_reltol        = 0.01
 ------------------------------------


Using WRMSNorm with cellwise norm values

Number of cells             = 2400
Number of DoFs in each cell = 6
Number of DoFs              = 14400

Taking time-step 1 at t = 0 ...
max error is 8.498980e-06 at t = 0.1 over the whole domain

Taking time-step 2 at t = 0.1 ...
max error is 5.434438e-06 at t = 0.2 over the whole domain

Taking time-step 3 at t = 0.2 ...
max error is 8.182732e-06 at t = 0.3 over the whole domain

Taking time-step 4 at t = 0.3 ...
max error is 1.046601e-05 at t = 0.4 over the whole domain

Taking time-step 5 at t = 0.4 ...
max error is 1.219970e-05 at t = 0.5 over the whole domain

Taking time-step 6 at t = 0.5 ...
max error is 1.352297e-05 at t = 0.6 over the whole domain

Taking time-step 7 at t = 0.6 ...
max error is 1.459523e-05 at t = 0.7 over the whole domain

Taking time-step 8 at t = 0.7 ...
max error is 1.545209e-05 at t = 0.8 over the whole domain

Taking time-step 9 at t = 0.8 ...
max error is 1.609742e-05 at t = 0.9 over the whole domain

Taking time-step 10 at t = 0.9 ...
max error is 1.657865e-05 at t = 1 over the whole domain

Computed Solution Stats
Current time                  = 1.09057119329779
Steps                         = 15
Step attempts                 = 15
Stability limited steps       = 0
Accuracy limited steps        = 15
Error test fails              = 0
NLS step fails                = 0
Inequality constraint fails   = 0
Initial step size             = 0.00461599204063949
Last step size                = 0.117716388072475
Current step size             = 0.123596465013178
RHS fn evals                  = 185
Number of dom_eig updates     = 1
Number of fe calls for DEE    = 102
Number of iterations for DEE  = 102
Max. num. of stages used      = 16
Max. num. of stages allowed   = 200
Max. spectral radius          = 1094.13385137831
Min. spectral radius          = 1094.13385137831

max-in-space and max-in-time error is 1.657865e-05 over D x [0, 1]

Reference solution CPU time: 69.144445 seconds
 Computed solution CPU time: 0.105888 seconds
```
while running with 2 CPUs produces
```
[manaurer@stellar-amd gkeyll_diffusion]$ mpiexec -np 2 gk_diffusion_1x1v_p1 -M -c 2

gkeyll diffusion test problem:
 ------------------------------------
 k                 = 0.1
 tf                = 1
 ------------------------------------
 rtol              = 1.00e-05
 atol              = 1.00e-12
 hfixed            = 0.00e+00
 method            = 1
 eigfrequency      = 0
 stage_max_limit   = 200
 num SSP stages    = 4
 eigsafety         = 1.01
 ------------------------------------
 wrms norm type    = 2
 max steps         = 100000
 ------------------------------------
 dom_eig provided  = 0
 dee ID            = 0
 dee num_init_wups = 100
 dee num_succ_wups = 0
 dee_max_iters     = 1000
 dee_krylov_dim    = 3
 dee_reltol        = 0.01
 ------------------------------------


Using WRMSNorm with cellwise norm values

Number of cells             = 2400
Number of DoFs in each cell = 6
Number of DoFs              = 14400

Taking time-step 1 at t = 0 ...
max error is 2.335228e-05 at t = 0.1 over the whole domain

Taking time-step 2 at t = 0.1 ...
max error is 1.700844e-05 at t = 0.2 over the whole domain

Taking time-step 3 at t = 0.2 ...
max error is 1.527191e-05 at t = 0.3 over the whole domain

Taking time-step 4 at t = 0.3 ...
max error is 1.362976e-05 at t = 0.4 over the whole domain

Taking time-step 5 at t = 0.4 ...
max error is 1.305123e-05 at t = 0.5 over the whole domain

Taking time-step 6 at t = 0.5 ...
max error is 1.233563e-05 at t = 0.6 over the whole domain

Taking time-step 7 at t = 0.6 ...
max error is 1.165146e-05 at t = 0.7 over the whole domain

Taking time-step 8 at t = 0.7 ...
max error is 1.138808e-05 at t = 0.8 over the whole domain

Taking time-step 9 at t = 0.8 ...
max error is 1.102667e-05 at t = 0.9 over the whole domain

Taking time-step 10 at t = 0.9 ...
max error is 1.066049e-05 at t = 1 over the whole domain

Computed Solution Stats
Current time                  = 1.03186394615891
Steps                         = 125
Step attempts                 = 125
Stability limited steps       = 0
Accuracy limited steps        = 125
Error test fails              = 0
NLS step fails                = 0
Inequality constraint fails   = 0
Initial step size             = 2.13234904917012e-08
Last step size                = 0.0412361613415795
Current step size             = 0.0428629731625346
RHS fn evals                  = 490
Number of dom_eig updates     = 1
Number of fe calls for DEE    = 102
Number of iterations for DEE  = 102
Max. num. of stages used      = 10
Max. num. of stages allowed   = 200
Max. spectral radius          = 1094.13385167274
Min. spectral radius          = 1094.13385167274

max-in-space and max-in-time error is 2.335228e-05 over D x [0, 1]

Reference solution CPU time: 34.960199 seconds
 Computed solution CPU time: 0.114581 seconds
```

Notably the number of steps is 8X larger with 2 CPUs, so something must be wrong still.

Additional info
--------------
Note that to build you may need to change the location of the gkylzero and sundials libraries, the former can be in `deps/gkyl-install` or `deps/gkylsoft` (gkylsoft is preferable), and the latter can be in a `deps/sundials-install/lib` or `deps/sundials-install/lib64` (depending on the system). You may need to change these manually in the Makefile.